### PR TITLE
Fix Codecov: exclude GPU crates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "crates/tropical-gemm-cuda/**"


### PR DESCRIPTION
CI runs without GPU hardware, so CUDA crates show 0% coverage.

This adds `codecov.yml` to exclude them from coverage reporting.

c.f.: https://docs.codecov.com/docs/ignoring-paths