### PR TITLE
fix(cuda): batched argmax kernel uses unsigned int* (u32)

### DIFF
--- a/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
+++ b/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
@@ -1140,7 +1140,7 @@ extern "C" __global__ void KERNEL_NAME(                                        \
     const float* A_batch = A + batch_idx * strideA;                            \
     const float* B_batch = B + batch_idx * strideB;                            \
     float* C_batch = C + batch_idx * strideC;                                  \
-    int* argmax_batch = argmax + batch_idx * strideC;                          \
+    unsigned int* argmax_batch = argmax + batch_idx * strideC;                          \
                                                                                \
     const int tid = threadIdx.y * bszm + threadIdx.x;                          \
                                                                                \


### PR DESCRIPTION
## Problem

The batched argmax kernel macro `TROPICAL_GEMM_BATCHED_ARGMAX_F32` in `crates/tropical-gemm-cuda/kernels/tropical_gemm.cu` declared the per-batch pointer as `int*` while the kernel parameter is `unsigned int*` (u32, since the unified-u32 argmax change). nvrtc rejects this at JIT time:

```
error: a value of type "unsigned int *" cannot be used to initialize an entity of type "int *"
  TROPICAL_GEMM_BATCHED_ARGMAX_F32(tropical_maxplus_f32_nn_batched_with_argmax, ...)
```

Because nvrtc compiles the whole `.cu` as a single program, this failed compilation of **all** GPU kernels — so every GPU path (batched *and* non-batched) was unusable. It was never caught because CUDA kernels are JIT-compiled only on a real GPU, and CI skips CUDA.

## Fix

One line: `int* argmax_batch` → `unsigned int* argmax_batch` (line ~1143), matching the kernel parameter and the non-batched argmax kernels (which use `unsigned int*` and write to `argmax[...]` directly).

## Validation

On HKUST-GZ HPC (NVIDIA A40, `debug` queue): with this change the full `tropical-gemm-python` test suite passes **207 passed, 0 failed**, including all CUDA DLPack zero-copy / batched tests. Without it, the same suite shows 25 GPU failures (nvrtc compile error → poisoned CUDA context).

Surfaced while validating the pyo3-dlpack migration (#49); this kernel fix is independent of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)