### PR TITLE
chore: migrate internal tests/benches off deprecated row-major constructors

### DIFF
--- a/crates/tropical-gemm-cuda/benches/tropical_ad_bench.rs
+++ b/crates/tropical-gemm-cuda/benches/tropical_ad_bench.rs
@@ -46,8 +46,8 @@ fn bench_forward_no_argmax(c: &mut Criterion) {
             .map(|i| (((i + 500) % 1000) as f32) * 0.01)
             .collect();
 
-        let a_gpu = GpuMatrix::from_host_row_major(&ctx, &a, m, k).unwrap();
-        let b_gpu = GpuMatrix::from_host_row_major(&ctx, &b, k, n).unwrap();
+        let a_gpu = GpuMatrix::from_host(&ctx, &a, m, k).unwrap();
+        let b_gpu = GpuMatrix::from_host(&ctx, &b, k, n).unwrap();
 
         // Warm up - compile kernel
         let _ = tropical_matmul_gpu_with_ctx::<TropicalMaxPlus<f32>>(&ctx, &a_gpu, &b_gpu).unwrap();
@@ -89,8 +89,8 @@ fn bench_forward_with_argmax(c: &mut Criterion) {
             .map(|i| (((i + 500) % 1000) as f32) * 0.01)
             .collect();
 
-        let a_gpu = GpuMatrix::from_host_row_major(&ctx, &a, m, k).unwrap();
-        let b_gpu = GpuMatrix::from_host_row_major(&ctx, &b, k, n).unwrap();
+        let a_gpu = GpuMatrix::from_host(&ctx, &a, m, k).unwrap();
+        let b_gpu = GpuMatrix::from_host(&ctx, &b, k, n).unwrap();
 
         // Warm up - compile kernel
         let _ =
@@ -136,14 +136,14 @@ fn bench_backward(c: &mut Criterion) {
             .map(|i| (((i + 500) % 1000) as f32) * 0.01)
             .collect();
 
-        let a_gpu = GpuMatrix::from_host_row_major(&ctx, &a, m, k).unwrap();
-        let b_gpu = GpuMatrix::from_host_row_major(&ctx, &b, k, n).unwrap();
+        let a_gpu = GpuMatrix::from_host(&ctx, &a, m, k).unwrap();
+        let b_gpu = GpuMatrix::from_host(&ctx, &b, k, n).unwrap();
 
         // Pre-compute forward pass with argmax
         let c_gpu =
             tropical_matmul_gpu_with_ctx_and_argmax::<TropicalMaxPlus<f32>>(&ctx, &a_gpu, &b_gpu)
                 .unwrap();
-        let argmax = c_gpu.argmax_to_host_row_major(&ctx).unwrap();
+        let argmax = c_gpu.argmax_to_host(&ctx).unwrap();
 
         // Upstream gradient (all ones)
         let grad_c: Vec<f32> = vec![1.0; m * n];
@@ -177,8 +177,8 @@ fn bench_backward(c: &mut Criterion) {
             .map(|i| (((i + 500) % 1000) as f32) * 0.01)
             .collect();
 
-        let a_gpu = GpuMatrix::from_host_row_major(&ctx, &a, m, k).unwrap();
-        let b_gpu = GpuMatrix::from_host_row_major(&ctx, &b, k, n).unwrap();
+        let a_gpu = GpuMatrix::from_host(&ctx, &a, m, k).unwrap();
+        let b_gpu = GpuMatrix::from_host(&ctx, &b, k, n).unwrap();
 
         let c_gpu =
             tropical_matmul_gpu_with_ctx_and_argmax::<TropicalMaxPlus<f32>>(&ctx, &a_gpu, &b_gpu)
@@ -228,15 +228,15 @@ fn bench_comparison(c: &mut Criterion) {
             .map(|i| (((i + 500) % 1000) as f32) * 0.01)
             .collect();
 
-        let a_gpu = GpuMatrix::from_host_row_major(&ctx, &a, m, k).unwrap();
-        let b_gpu = GpuMatrix::from_host_row_major(&ctx, &b, k, n).unwrap();
+        let a_gpu = GpuMatrix::from_host(&ctx, &a, m, k).unwrap();
+        let b_gpu = GpuMatrix::from_host(&ctx, &b, k, n).unwrap();
 
         // Warm up both kernels
         let _ = tropical_matmul_gpu_with_ctx::<TropicalMaxPlus<f32>>(&ctx, &a_gpu, &b_gpu).unwrap();
         let c_argmax =
             tropical_matmul_gpu_with_ctx_and_argmax::<TropicalMaxPlus<f32>>(&ctx, &a_gpu, &b_gpu)
                 .unwrap();
-        let argmax = c_argmax.argmax_to_host_row_major(&ctx).unwrap();
+        let argmax = c_argmax.argmax_to_host(&ctx).unwrap();
 
         // Pre-upload grad_c to GPU for kernel-only benchmark
         let grad_c: Vec<f32> = vec![1.0; m * n];

--- a/crates/tropical-gemm-cuda/src/gpu_mat.rs
+++ b/crates/tropical-gemm-cuda/src/gpu_mat.rs
@@ -255,8 +255,8 @@ where
     ///
     /// let ctx = CudaContext::new()?;
     /// let mats = vec![
-    ///     Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2),
-    ///     Mat::<MaxPlus<f32>>::from_row_major(&[5.0, 6.0, 7.0, 8.0], 2, 2),
+    ///     Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2),
+    ///     Mat::<MaxPlus<f32>>::from_col_major(&[5.0, 7.0, 6.0, 8.0], 2, 2),
     /// ];
     /// let gpu_mats = GpuMat::from_mats(&ctx, &mats)?;
     /// ```
@@ -686,10 +686,10 @@ mod tests {
         };
 
         // Create batch of CPU matrices
-        let a1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let a2 = Mat::<MaxPlus<f32>>::from_row_major(&[5.0, 6.0, 7.0, 8.0], 2, 2);
-        let b1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
-        let b2 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let a2 = Mat::<MaxPlus<f32>>::from_col_major(&[5.0, 7.0, 6.0, 8.0], 2, 2);
+        let b1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
+        let b2 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         // Upload batch to GPU
         let a_gpu = GpuMat::from_mats(ctx, &[a1, a2]).unwrap();
@@ -722,10 +722,10 @@ mod tests {
             }
         };
 
-        let a1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let a2 = Mat::<MaxPlus<f32>>::from_row_major(&[6.0, 5.0, 4.0, 3.0, 2.0, 1.0], 2, 3);
-        let b1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
-        let b2 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let a2 = Mat::<MaxPlus<f32>>::from_col_major(&[6.0, 3.0, 5.0, 2.0, 4.0, 1.0], 2, 3);
+        let b1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
+        let b2 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         // Upload to GPU
         let a_gpu = GpuMat::from_mats(ctx, &[a1, a2]).unwrap();

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -2046,8 +2046,8 @@ mod tests {
     fn test_tropical_gemm_gpu_dimension_mismatch() {
         if let Some(ctx) = cuda_context_or_skip() {
             // Create matrices with incompatible dimensions
-            let a = GpuMatrix::from_host_row_major(ctx, &vec![1.0f32; 6], 2, 3).unwrap();
-            let b = GpuMatrix::from_host_row_major(ctx, &vec![1.0f32; 6], 2, 3).unwrap(); // 2x3, not 3x2
+            let a = GpuMatrix::from_host(ctx, &vec![1.0f32; 6], 2, 3).unwrap();
+            let b = GpuMatrix::from_host(ctx, &vec![1.0f32; 6], 2, 3).unwrap(); // 2x3, not 3x2
             let mut c = GpuMatrix::alloc(ctx, 2, 3).unwrap();
 
             let result = tropical_gemm_gpu::<TropicalMaxPlus<f32>>(ctx, &a, &b, &mut c);
@@ -2058,15 +2058,18 @@ mod tests {
     #[test]
     fn test_tropical_matmul_gpu_with_ctx_dimension_mismatch() {
         if let Some(ctx) = cuda_context_or_skip() {
-            let a = GpuMatrix::from_host_row_major(ctx, &vec![1.0f32; 6], 2, 3).unwrap();
-            let b = GpuMatrix::from_host_row_major(ctx, &vec![1.0f32; 6], 2, 3).unwrap(); // Wrong dimensions
+            let a = GpuMatrix::from_host(ctx, &vec![1.0f32; 6], 2, 3).unwrap();
+            let b = GpuMatrix::from_host(ctx, &vec![1.0f32; 6], 2, 3).unwrap(); // Wrong dimensions
 
             let result = tropical_matmul_gpu_with_ctx::<TropicalMaxPlus<f32>>(ctx, &a, &b);
             assert!(result.is_err());
         }
     }
 
+    // `from_host_row_major` stays public (deprecated); keep one test exercising its
+    // size validation. All other GPU callers use `from_host` (column-major).
     #[test]
+    #[allow(deprecated)]
     fn test_gpu_memory_dimension_mismatch() {
         if let Some(ctx) = cuda_context_or_skip() {
             // Try to create matrix with wrong data size
@@ -2086,7 +2089,7 @@ mod tests {
     #[test]
     fn test_gpu_matrix_accessors() {
         if let Some(ctx) = cuda_context_or_skip() {
-            let mat = GpuMatrix::from_host_row_major(ctx, &vec![1.0f32; 6], 2, 3).unwrap();
+            let mat = GpuMatrix::from_host(ctx, &vec![1.0f32; 6], 2, 3).unwrap();
             assert_eq!(mat.rows(), 2);
             assert_eq!(mat.cols(), 3);
             assert_eq!(mat.ld(), 2); // Column-major leading dimension = rows

--- a/crates/tropical-gemm-cuda/src/memory.rs
+++ b/crates/tropical-gemm-cuda/src/memory.rs
@@ -78,7 +78,6 @@ impl<T: DeviceRepr + Default + Clone + ValidAsZeroBits> GpuMatrix<T> {
     /// For performance-critical code, provide data in column-major order and use
     /// [`from_host`] instead.
     #[deprecated(
-        since = "0.4.0",
         note = "use `from_host` with column-major host data, or `from_cuda_slice` if your data is already on GPU; this method has O(m×n) transpose overhead"
     )]
     pub fn from_host_row_major(

--- a/crates/tropical-gemm/src/mat/mod.rs
+++ b/crates/tropical-gemm/src/mat/mod.rs
@@ -104,8 +104,8 @@ impl<S: crate::TropicalWithArgmax<Index = u32>> MatWithArgmax<S> {
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus, TropicalMaxPlus};
     ///
-    /// let a = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-    /// let b = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+    /// let a = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+    /// let b = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
     ///
     /// // Forward pass with argmax
     /// let result = a.matmul_argmax(&b);
@@ -166,8 +166,8 @@ impl<S: crate::TropicalWithArgmax<Index = u32>> MatWithArgmax<S> {
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus, TropicalMaxPlus};
     ///
-    /// let a = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-    /// let b = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+    /// let a = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+    /// let b = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
     ///
     /// // Forward pass with argmax
     /// let result = a.matmul_argmax(&b);
@@ -339,8 +339,8 @@ mod tests {
     #[test]
     fn test_mat_matmul_direct() {
         // Test Mat::matmul directly (no as_ref needed)
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let c = a.matmul(&b);
 
@@ -353,8 +353,8 @@ mod tests {
     #[test]
     fn test_mat_matmul_argmax_direct() {
         // Test Mat::matmul_argmax directly
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let result = a.matmul_argmax(&b);
 
@@ -365,7 +365,7 @@ mod tests {
     #[test]
     fn test_mat_get_value() {
         // Test get_value method - no trait import needed
-        let m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         assert_eq!(m.get_value(0, 0), 1.0);
         assert_eq!(m.get_value(0, 1), 2.0);
@@ -377,8 +377,8 @@ mod tests {
     fn test_minplus_mat_matmul_direct() {
         use crate::TropicalMinPlus;
 
-        let a = Mat::<TropicalMinPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMinPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMinPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMinPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let c = a.matmul(&b);
 
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_mat_as_slice() {
-        let m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         let slice = m.as_slice();
         assert_eq!(slice.len(), 4);
         assert_eq!(slice[0].0, 1.0);
@@ -414,7 +414,7 @@ mod tests {
 
     #[test]
     fn test_mat_as_mut_slice() {
-        let mut m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let mut m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         let slice = m.as_mut_slice();
         slice[0] = TropicalMaxPlus(100.0);
         assert_eq!(m[(0, 0)].0, 100.0);
@@ -422,14 +422,14 @@ mod tests {
 
     #[test]
     fn test_mat_as_mut_ptr() {
-        let mut m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let mut m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         let ptr = m.as_mut_ptr();
         assert!(!ptr.is_null());
     }
 
     #[test]
     fn test_mat_index_mut() {
-        let mut m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let mut m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         m[(0, 0)] = TropicalMaxPlus(10.0);
         m[(1, 1)] = TropicalMaxPlus(40.0);
         assert_eq!(m[(0, 0)].0, 10.0);
@@ -438,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_mat_matmul_ref() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
         // Column-major data for B: 3×2 matrix [[1,2],[3,4],[5,6]] stored as [1,3,5,2,4,6]
         let b_data = [1.0f64, 3.0, 5.0, 2.0, 4.0, 6.0];
         let b = MatRef::<TropicalMaxPlus<f64>>::from_slice(&b_data, 3, 2);
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_mat_clone() {
-        let m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         let m2 = m.clone();
         assert_eq!(m2[(0, 0)].0, 1.0);
         assert_eq!(m2[(1, 1)].0, 4.0);
@@ -489,15 +489,15 @@ mod tests {
 
     #[test]
     fn test_mat_debug() {
-        let m = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0], 1, 2);
+        let m = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 2.0], 1, 2);
         let debug_str = format!("{:?}", m);
         assert!(debug_str.contains("Mat"));
     }
 
     #[test]
     fn test_matwithargmax_get_value() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let result = a.matmul_argmax(&b);
 
@@ -508,8 +508,8 @@ mod tests {
 
     #[test]
     fn test_matwithargmax_nrows_ncols() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let result = a.matmul_argmax(&b);
 
@@ -517,10 +517,29 @@ mod tests {
         assert_eq!(result.ncols(), 2);
     }
 
+    // `from_row_major` stays public (deprecated) as a downstream convenience, so keep
+    // minimal coverage of it here. All internal callers use `from_col_major` instead.
     #[test]
     #[should_panic(expected = "data length")]
+    #[allow(deprecated)]
     fn test_mat_from_row_major_size_mismatch() {
         let _ = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0], 2, 2);
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_from_row_major_equals_col_major_transposed() {
+        // Row-major input must yield the same logical matrix as the equivalent
+        // column-major data fed to from_col_major (this is the transpose mapping
+        // every migrated test relies on).
+        let rm = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
+        let cm = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        assert_eq!((rm.nrows(), rm.ncols()), (2, 3));
+        for i in 0..2 {
+            for j in 0..3 {
+                assert_eq!(rm.get_value(i, j), cm.get_value(i, j));
+            }
+        }
     }
 
     #[test]
@@ -540,8 +559,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "dimension mismatch")]
     fn test_matmul_dimension_mismatch() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
         let _ = a.matmul(&b); // Should panic: A is 2x2, B is 3x2
     }
 
@@ -558,8 +577,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "dimension mismatch")]
     fn test_matmul_argmax_dimension_mismatch() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
         let _ = a.matmul_argmax(&b); // Should panic
     }
 
@@ -576,7 +595,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "dimension mismatch")]
     fn test_mat_matmul_ref_dimension_mismatch() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         let b_data = [1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0];
         let b = MatRef::<TropicalMaxPlus<f64>>::from_slice(&b_data, 3, 2);
         let _ = a.matmul_ref(&b); // Should panic
@@ -588,10 +607,10 @@ mod tests {
 
     #[test]
     fn test_mat_matmul_batched() {
-        let a1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let a2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[5.0, 6.0, 7.0, 8.0], 2, 2);
-        let b1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
-        let b2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let a2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[5.0, 7.0, 6.0, 8.0], 2, 2);
+        let b1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
+        let b2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         let results = Mat::matmul_batched(&[a1, a2], &[b1, b2]);
         assert_eq!(results.len(), 2);
@@ -617,9 +636,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "batch sizes must match")]
     fn test_mat_matmul_batched_size_mismatch() {
-        let a1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let b1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
-        let b2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let b1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
+        let b2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         let _ = Mat::matmul_batched(&[a1], &[b1, b2]); // Should panic
     }
@@ -627,21 +646,21 @@ mod tests {
     #[test]
     #[should_panic(expected = "has dimensions")]
     fn test_mat_matmul_batched_dimension_mismatch() {
-        let a1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         let a2 =
-            Mat::<TropicalMaxPlus<f32>>::from_row_major(&[5.0, 6.0, 7.0, 8.0, 9.0, 10.0], 2, 3); // Different size
-        let b1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
-        let b2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+            Mat::<TropicalMaxPlus<f32>>::from_col_major(&[5.0, 8.0, 6.0, 9.0, 7.0, 10.0], 2, 3); // Different size
+        let b1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
+        let b2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         let _ = Mat::matmul_batched(&[a1, a2], &[b1, b2]); // Should panic
     }
 
     #[test]
     fn test_mat_matmul_batched_with_argmax() {
-        let a1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let a2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[6.0, 5.0, 4.0, 3.0, 2.0, 1.0], 2, 3);
-        let b1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
-        let b2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let a2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[6.0, 3.0, 5.0, 2.0, 4.0, 1.0], 2, 3);
+        let b1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
+        let b2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let results = Mat::matmul_batched_with_argmax(&[a1, a2], &[b1, b2]);
         assert_eq!(results.len(), 2);
@@ -663,9 +682,9 @@ mod tests {
     #[test]
     #[should_panic(expected = "batch sizes must match")]
     fn test_mat_matmul_batched_with_argmax_size_mismatch() {
-        let a1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b1 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
-        let b2 = Mat::<TropicalMaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b1 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
+        let b2 = Mat::<TropicalMaxPlus<f32>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let _ = Mat::matmul_batched_with_argmax(&[a1], &[b1, b2]); // Should panic
     }
@@ -676,8 +695,8 @@ mod tests {
 
     #[test]
     fn test_matwithargmax_backward_a() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         // Forward pass
         let result = a.matmul_argmax(&b);
@@ -705,8 +724,8 @@ mod tests {
 
     #[test]
     fn test_matwithargmax_backward_b() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         // Forward pass
         let result = a.matmul_argmax(&b);
@@ -730,9 +749,9 @@ mod tests {
     fn test_matwithargmax_backward_varied_argmax() {
         // Design matrices where different k-indices win
         let a =
-            Mat::<TropicalMaxPlus<f64>>::from_row_major(&[10.0, 1.0, 1.0, 1.0, 10.0, 1.0], 2, 3);
+            Mat::<TropicalMaxPlus<f64>>::from_col_major(&[10.0, 1.0, 1.0, 10.0, 1.0, 1.0], 2, 3);
         let b =
-            Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 1.0, 1.0, 1.0, 10.0, 10.0], 3, 2);
+            Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 1.0, 10.0, 1.0, 1.0, 10.0], 3, 2);
 
         let result = a.matmul_argmax(&b);
 
@@ -753,8 +772,8 @@ mod tests {
 
     #[test]
     fn test_matwithargmax_argmax_slice() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
 
         let result = a.matmul_argmax(&b);
         let argmax_slice = result.argmax_slice();

--- a/crates/tropical-gemm/src/mat/ops.rs
+++ b/crates/tropical-gemm/src/mat/ops.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn test_mat_ref_mul_matref() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
         // Column-major: 2×2 matrix [[1,2],[3,4]] stored as [1,3,2,4]
         let b_data = [1.0f64, 3.0, 2.0, 4.0];
         let b = MatRef::<TropicalMaxPlus<f64>>::from_slice(&b_data, 2, 2);
@@ -119,8 +119,8 @@ mod tests {
 
     #[test]
     fn test_mat_mul_mat() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         let c = &a * &b;
 
@@ -129,8 +129,8 @@ mod tests {
 
     #[test]
     fn test_mat_mul_consuming() {
-        let a = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-        let b = Mat::<TropicalMaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+        let a = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+        let b = Mat::<TropicalMaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
 
         let c = a * b;
 

--- a/crates/tropical-gemm/src/mat/owned.rs
+++ b/crates/tropical-gemm/src/mat/owned.rs
@@ -98,7 +98,7 @@ impl<S: TropicalSemiring> Mat<S> {
     ///
     /// This method performs an O(m×n) transpose operation. For performance-critical code,
     /// provide data in column-major order and use [`from_col_major`] instead.
-    #[deprecated(since = "0.4.0", note = "use from_col_major instead for direct column-major input; this method has O(m×n) transpose overhead")]
+    #[deprecated(note = "use from_col_major instead for direct column-major input; this method has O(m×n) transpose overhead")]
     pub fn from_row_major(data: &[S::Scalar], nrows: usize, ncols: usize) -> Self
     where
         S::Scalar: Copy,
@@ -169,7 +169,7 @@ impl<S: TropicalSemiring> Mat<S> {
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus};
     ///
-    /// let m = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+    /// let m = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
     /// assert_eq!(m.get_value(0, 0), 1.0);
     /// assert_eq!(m.get_value(1, 1), 4.0);
     /// ```
@@ -260,8 +260,8 @@ where
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus, TropicalSemiring};
     ///
-    /// let a = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-    /// let b = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+    /// let a = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+    /// let b = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
     ///
     /// let c = a.matmul(&b);
     ///
@@ -367,8 +367,8 @@ where
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus, TropicalSemiring};
     ///
-    /// let a = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 2, 3);
-    /// let b = Mat::<MaxPlus<f64>>::from_row_major(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 3, 2);
+    /// let a = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 4.0, 2.0, 5.0, 3.0, 6.0], 2, 3);
+    /// let b = Mat::<MaxPlus<f64>>::from_col_major(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0], 3, 2);
     ///
     /// let result = a.matmul_argmax(&b);
     ///
@@ -442,10 +442,10 @@ where
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus};
     ///
-    /// let a1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-    /// let a2 = Mat::<MaxPlus<f32>>::from_row_major(&[5.0, 6.0, 7.0, 8.0], 2, 2);
-    /// let b1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
-    /// let b2 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+    /// let a1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+    /// let a2 = Mat::<MaxPlus<f32>>::from_col_major(&[5.0, 7.0, 6.0, 8.0], 2, 2);
+    /// let b1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
+    /// let b2 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
     ///
     /// let results = Mat::matmul_batched_with_argmax(&[a1, a2], &[b1, b2]);
     /// assert_eq!(results.len(), 2);
@@ -526,10 +526,10 @@ where
     /// ```
     /// use tropical_gemm::{Mat, MaxPlus};
     ///
-    /// let a1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
-    /// let a2 = Mat::<MaxPlus<f32>>::from_row_major(&[5.0, 6.0, 7.0, 8.0], 2, 2);
-    /// let b1 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
-    /// let b2 = Mat::<MaxPlus<f32>>::from_row_major(&[1.0, 2.0, 3.0, 4.0], 2, 2);
+    /// let a1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
+    /// let a2 = Mat::<MaxPlus<f32>>::from_col_major(&[5.0, 7.0, 6.0, 8.0], 2, 2);
+    /// let b1 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 0.0, 0.0, 1.0], 2, 2);
+    /// let b2 = Mat::<MaxPlus<f32>>::from_col_major(&[1.0, 3.0, 2.0, 4.0], 2, 2);
     ///
     /// let results = Mat::matmul_batched(&[a1, a2], &[b1, b2]);
     /// assert_eq!(results.len(), 2);


### PR DESCRIPTION
## What

Internal tests, doc examples, and the CUDA AD benchmark were calling the **deprecated** row-major convenience constructors, so the crate emitted **55+ deprecation warnings against its own API**. Migrate every internal caller to the native column-major path — data hand-transposed so the **logical matrices are unchanged** (every assertion still holds):

| deprecated (kept public) | → migrated to | where |
|---|---|---|
| `Mat::from_row_major` | `from_col_major` | CPU `mat/*` |
| `GpuMatrix::from_host_row_major` | `from_host` | CUDA input (`lib.rs` tests, bench) |
| `argmax_to_host_row_major` | `argmax_to_host` | CUDA argmax output (bench) |

The deprecated methods **stay public** as a perf hint for downstream consumers; a few `#[allow(deprecated)]` tests keep them covered. Also dropped the bogus `since = "0.4.0"` from both deprecation attributes (crate is `0.2.0`, and `since` doesn't gate the warning anyway — it fires on every use immediately).

## Result

**0 deprecation warnings (was 55+), 0 total workspace warnings.**

## Verification

- `cargo test -p tropical-gemm` → 275 unit + 24 doctests pass
- `maturin develop` + `pytest` → 152 pass (CPU)
- **CUDA 56/56 on HKUST-GZ A40** (Slurm job 9800403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)