### PR TITLE
deps: upgrade wide/thiserror/criterion + once_cell→std; fast_max/min recovers ~2.2x AVX2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +84,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,25 +153,24 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -160,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -235,6 +253,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -330,12 +354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,21 +372,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -510,6 +517,16 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -832,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "safe_arch"
-version = "0.7.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
 dependencies = [
  "bytemuck",
 ]
@@ -898,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -935,18 +958,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -980,7 +1003,6 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "cudarc",
- "once_cell",
  "thiserror",
  "tropical-gemm",
 ]
@@ -1142,13 +1164,29 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.33"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
 dependencies = [
  "bytemuck",
  "safe_arch",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -1158,6 +1196,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tropical-gemm = { version = "0.2.0", path = "crates/tropical-gemm" }
 
 # External dependencies
 num-traits = "0.2"
-wide = "0.7"
+wide = "1"
 rayon = "1.10"
 # CUDA version is a deliberate VARIABLE — never hardcode a `cuda-XXXXX` feature here.
 # cudarc's build.rs selects the version as: (1) `CUDARC_CUDA_VERSION` env (e.g.
@@ -33,8 +33,8 @@ rayon = "1.10"
 #   • macOS dev (no nvcc): `fallback-latest` picks cudarc's newest supported version,
 #     purely so `cargo check` compiles (dynamic-loading → never actually runs CUDA).
 cudarc = { version = "0.19.7", default-features = false, features = ["std", "driver", "nvrtc", "dynamic-loading", "cuda-version-from-build-system", "fallback-latest"] }
-thiserror = "1.0"
+thiserror = "2.0"
 
 # Testing
-criterion = "0.5"
+criterion = "0.8"
 proptest = "1.0"

--- a/crates/tropical-gemm-cuda/Cargo.toml
+++ b/crates/tropical-gemm-cuda/Cargo.toml
@@ -14,7 +14,6 @@ readme = "../../README.md"
 tropical-gemm = { workspace = true }
 cudarc = { workspace = true }
 thiserror = { workspace = true }
-once_cell = "1.19"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/tropical-gemm-cuda/benches/tropical_ad_bench.rs
+++ b/crates/tropical-gemm-cuda/benches/tropical_ad_bench.rs
@@ -9,7 +9,8 @@
 //! GPU only, MaxPlus algebra only.
 //! Uses persistent CudaContext to exclude JIT compilation overhead.
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 use tropical_gemm::TropicalMaxPlus;
 use tropical_gemm_cuda::{
     tropical_backward_a_gpu, tropical_backward_a_gpu_kernel, tropical_backward_b_gpu,

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -95,12 +95,11 @@ mod kernels;
 mod memory;
 
 use cudarc::driver::CudaContext as CudaCtx;
-use once_cell::sync::OnceCell;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 /// Per-device CUDA context cache, dynamically sized based on available devices.
-static DEVICE_CONTEXTS: OnceCell<Mutex<HashMap<usize, &'static CudaContext>>> = OnceCell::new();
+static DEVICE_CONTEXTS: OnceLock<Mutex<HashMap<usize, &'static CudaContext>>> = OnceLock::new();
 
 /// Mutex to ensure thread-safe initialization.
 static INIT_MUTEX: Mutex<()> = Mutex::new(());

--- a/crates/tropical-gemm/benches/gemm_bench.rs
+++ b/crates/tropical-gemm/benches/gemm_bench.rs
@@ -1,4 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 use tropical_gemm::prelude::*;
 use tropical_gemm::TropicalScalar; // for `neg_infinity()` (not in the prelude)
 

--- a/crates/tropical-gemm/src/simd/kernels/avx2.rs
+++ b/crates/tropical-gemm/src/simd/kernels/avx2.rs
@@ -58,8 +58,12 @@ impl Microkernel<TropicalMaxPlus<f32>> for Avx2MaxPlusF32Kernel {
                 let a_broadcast = f32x8::splat(a_vals[i]);
                 let product = a_broadcast + b_vec;
 
-                // Tropical add: max(acc, product)
-                acc[i] = acc[i].max(product);
+                // Tropical add: max(acc, product).
+                // fast_max == hardware maxps (1 instr). Plain max() adds an
+                // is_nan compare + blend (3 instr) we don't need: tropical
+                // MaxPlus inputs are finite or -inf, so +inf+-inf (the only
+                // NaN source) never occurs.
+                acc[i] = acc[i].fast_max(product);
             }
         }
 
@@ -120,7 +124,8 @@ impl Microkernel<TropicalMaxPlus<f64>> for Avx2MaxPlusF64Kernel {
             for i in 0..mr {
                 let a_broadcast = f64x4::splat(a_vals[i]);
                 let product = a_broadcast + b_vec;
-                acc[i] = acc[i].max(product);
+                // fast_max: no-NaN hardware max (see f32 kernel above).
+                acc[i] = acc[i].fast_max(product);
             }
         }
 
@@ -181,8 +186,10 @@ impl Microkernel<TropicalMinPlus<f32>> for Avx2MinPlusF32Kernel {
             for i in 0..mr {
                 let a_broadcast = f32x8::splat(a_vals[i]);
                 let product = a_broadcast + b_vec;
-                // MinPlus: tropical add = min
-                acc[i] = acc[i].min(product);
+                // MinPlus: tropical add = min.
+                // fast_min == hardware minps (1 instr); MinPlus inputs are
+                // finite or +inf, so the NaN-blend in plain min() is dead work.
+                acc[i] = acc[i].fast_min(product);
             }
         }
 
@@ -244,8 +251,9 @@ impl Microkernel<TropicalMaxMul<f32>> for Avx2MaxMulF32Kernel {
                 let a_broadcast = f32x8::splat(a_vals[i]);
                 // MaxMul: tropical mul = standard mul
                 let product = a_broadcast * b_vec;
-                // tropical add = max
-                acc[i] = acc[i].max(product);
+                // tropical add = max. fast_max: MaxMul inputs are finite (zero
+                // = 0.0), products finite → no NaN, so skip the NaN blend.
+                acc[i] = acc[i].fast_max(product);
             }
         }
 

--- a/crates/tropical-gemm/src/simd/kernels/neon.rs
+++ b/crates/tropical-gemm/src/simd/kernels/neon.rs
@@ -50,7 +50,11 @@ impl Microkernel<TropicalMaxPlus<f32>> for NeonMaxPlusF32Kernel {
             for i in 0..mr {
                 let a_broadcast = f32x4::splat(a_vals[i]);
                 let product = a_broadcast + b_vec;
-                acc[i] = acc[i].max(product);
+                // fast_max → vmaxq_f32 (single instr). wide 1.x's plain max()
+                // emits the NaN-aware vmaxnmq_f32 instead, which is slower on
+                // several cores; our finite/-inf inputs never produce NaN, so
+                // pin the plain single-instruction path explicitly.
+                acc[i] = acc[i].fast_max(product);
             }
         }
 
@@ -110,7 +114,8 @@ impl Microkernel<TropicalMaxPlus<f64>> for NeonMaxPlusF64Kernel {
             for i in 0..mr {
                 let a_broadcast = f64x2::splat(a_vals[i]);
                 let product = a_broadcast + b_vec;
-                acc[i] = acc[i].max(product);
+                // fast_max → vmaxq_f64; see f32 kernel for why fast is safe here.
+                acc[i] = acc[i].fast_max(product);
             }
         }
 
@@ -168,7 +173,10 @@ impl Microkernel<TropicalMinPlus<f32>> for NeonMinPlusF32Kernel {
             for i in 0..mr {
                 let a_broadcast = f32x4::splat(a_vals[i]);
                 let product = a_broadcast + b_vec;
-                acc[i] = acc[i].min(product);
+                // fast_min → vminq_f32; wide's plain min() uses NaN-aware
+                // vminnmq_f32. MinPlus inputs are finite/+inf, so the NaN
+                // handling is unnecessary work here.
+                acc[i] = acc[i].fast_min(product);
             }
         }
 


### PR DESCRIPTION
## Summary

Two connected changes — a dependency refresh, and the SIMD fix that the refresh turned out to need.

### 1. Dependency upgrades
- `wide` 0.7 → 1 (SIMD)
- `thiserror` 1.0 → 2.0
- `criterion` 0.5 → 0.8 (dev/bench only; `criterion::black_box` → `std::hint::black_box`)
- `once_cell` → std `OnceLock` (external dep removed from `tropical-gemm-cuda`)

### 2. fast_max/fast_min — recovering performance the `wide` bump silently cost

`wide` 1.x's `f32xN::max`/`min` are NaN-aware, and that handling is **not free**:

| arch | `.max()` / `.min()` (wide 1.x default) | `.fast_max()` / `.fast_min()` |
|---|---|---|
| **x86 AVX** | `max_m256` + `is_nan()` + `vblendvps` (3 ops + a `max→isnan→blend` dependency chain in the hot loop) | single `max_m256` |
| **ARM NEON** | NaN-aware `vmaxnmq_f32` / `vminnmq_f32` | plain `vmaxq_f32` / `vminq_f32` |

Tropical GEMM **never produces NaN** — MaxPlus inputs are finite or −∞, MinPlus finite or +∞, MaxMul finite (zero = 0.0) — so the only NaN source (`+∞ + −∞`) cannot occur and the NaN handling is dead work. Switching all 7 microkernels (avx2 ×4, neon ×3) to `fast_max`/`fast_min` lowers each to a single `maxps`/`minps`/`vmaxq`/`vminq`.

Without this, the `wide` 0.7→1.x bump alone **silently ~halves AVX2 throughput**.

## Benchmarks (A/B: `fast_*` vs default `max`/`min`, same wide 1.4.0, criterion, p < 0.05)

**x86 AVX2** (HKUST-GZ HPC, `f32`):

| size | default max/min | fast_* | speedup |
|---|---:|---:|---:|
| 128 | ~600 µs | ~291 µs | **2.07×** |
| 256 | ~4.59 ms | ~2.09 ms | **2.20×** |
| 512 | ~36.5 ms | ~16.4 ms | **2.22×** |
| 1024 | ~291 ms | ~131 ms | **2.23×** |

(MaxPlus / MinPlus / MaxMul all ≈ −54%.)

**ARM NEON** (Apple M-series, `f32`): −3% to −4% on MinPlus/MaxMul; MaxPlus ≈ flat.

## Correctness

`cargo test -p tropical-gemm` with `fast_*` in place: **279 unit + 24 doctests, 0 failures** on **both** x86 AVX2 (HPC) and ARM NEON (local). Includes the assertion-based AVX2 kernel unit tests. `cargo audit` clean. CUDA crate (thiserror 2.0 + once_cell→std + cudarc) builds and its 56 GPU tests pass on A40/CUDA 12.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)