### PR TITLE
feat(cuda): GPU TropicalAndOr + TropicalBitwise — close AndOr/Bitwise gap vs TropicalNumbers.jl (#44)

### DIFF
--- a/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
+++ b/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
@@ -78,6 +78,14 @@ __device__ __forceinline__ long long mul_i64(long long a, long long b) {
 __device__ __forceinline__ bool or_bool(bool a, bool b)  { return a | b; }
 __device__ __forceinline__ bool and_bool(bool a, bool b) { return a & b; }
 
+// Bit-packed boolean (Bitwise) semiring: add = OR, mul = AND, zero = 0, one = ~0.
+// Each bit-lane is an independent boolean problem. zero = 0 is a true absorbing
+// zero for AND (0 & x = 0), so the out-of-range tile PAD is simply 0.
+__device__ __forceinline__ unsigned int or_u32(unsigned int a, unsigned int b)  { return a | b; }
+__device__ __forceinline__ unsigned int and_u32(unsigned int a, unsigned int b) { return a & b; }
+__device__ __forceinline__ unsigned long long or_u64(unsigned long long a, unsigned long long b)  { return a | b; }
+__device__ __forceinline__ unsigned long long and_u64(unsigned long long a, unsigned long long b) { return a & b; }
+
 // Drifted tropical-zero detection for argmax canonicalization. A no-contribution
 // output cell's value sits in "infinity territory" (past S/2) after the
 // guard-free add drifts it (`S + data`). Used ONLY at the O(M*N) write-out (not
@@ -492,6 +500,176 @@ extern "C" __global__ void KERNEL_NAME(                                        \
     bool accum[THREAD_SIZE_M * THREAD_SIZE_N];                                 \
     bool regs_a[THREAD_SIZE_M];                                                \
     bool regs_b[THREAD_SIZE_N];                                                \
+                                                                               \
+    _Pragma("unroll")                                                          \
+    for (int i = 0; i < THREAD_SIZE_M * THREAD_SIZE_N; ++i) {                  \
+        accum[i] = INIT_VAL;                                                   \
+    }                                                                          \
+                                                                               \
+    const int A_TILE_COL = tid / BLOCK_SIZE_M;                                 \
+    const int A_TILE_ROW = tid % BLOCK_SIZE_M;                                 \
+    const int B_TILE_COL = tid / BLOCK_SIZE_K;                                 \
+    const int B_TILE_ROW = tid % BLOCK_SIZE_K;                                 \
+    const int A_TILE_COL_STRIDE = THREAD_NUM_PER_BLOCK / BLOCK_SIZE_M;         \
+    const int B_TILE_COL_STRIDE = THREAD_NUM_PER_BLOCK / BLOCK_SIZE_K;         \
+                                                                               \
+    for (int tile_idx = 0; tile_idx < K; tile_idx += BLOCK_SIZE_K) {           \
+        LOAD_A_TILE(A, INIT_VAL)                                          \
+                                                                               \
+        LOAD_B_TILE(B, INIT_VAL)                                          \
+                                                                               \
+        __syncthreads();                                                       \
+                                                                               \
+        _Pragma("unroll")                                                      \
+        for (int k = 0; k < BLOCK_SIZE_K; ++k) {                               \
+            _Pragma("unroll")                                                  \
+            for (int tm = 0; tm < THREAD_SIZE_M; ++tm) {                       \
+                regs_a[tm] = As[OFFSET_COL(threadIdx.x * THREAD_SIZE_M + tm,   \
+                                           k, BLOCK_SIZE_M)];                  \
+            }                                                                  \
+            _Pragma("unroll")                                                  \
+            for (int tn = 0; tn < THREAD_SIZE_N; ++tn) {                       \
+                regs_b[tn] = Bs[OFFSET_COL(k, threadIdx.y * THREAD_SIZE_N + tn,\
+                                           BLOCK_SIZE_K)];                     \
+            }                                                                  \
+            _Pragma("unroll")                                                  \
+            for (int tm = 0; tm < THREAD_SIZE_M; ++tm) {                       \
+                _Pragma("unroll")                                              \
+                for (int tn = 0; tn < THREAD_SIZE_N; ++tn) {                   \
+                    int idx = OFFSET_COL(tm, tn, THREAD_SIZE_M);               \
+                    accum[idx] = COMPARE_FN(MUL_FN(regs_a[tm], regs_b[tn]),    \
+                                            accum[idx]);                       \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+        __syncthreads();                                                       \
+    }                                                                          \
+                                                                               \
+        STORE_C_TILE(C)                                                   \
+}
+
+// ============================================================================
+// U32 GEMM KERNEL MACRO (Bitwise semiring, bit-packed boolean)
+// ============================================================================
+// Identical tiling to I32 (64x32x64, 4x4) on a 4-byte `unsigned int` element.
+// add = OR (COMPARE_FN), mul = AND (MUL_FN), tropical zero = 0; PAD = 0 is the
+// absorbing zero for AND. Being a 4-byte element, this shares the i32 kernel's
+// shared-load path rather than the 1-byte bool kernel's per-byte loads — verify
+// the win on HW with `cuobjdump -sass` (expect LDS, not LDS.U8).
+
+#define TROPICAL_GEMM_U32(KERNEL_NAME, INIT_VAL, COMPARE_FN, MUL_FN)            \
+extern "C" __global__ void KERNEL_NAME(                                        \
+    const unsigned int* __restrict__ A,                                        \
+    const unsigned int* __restrict__ B,                                        \
+    unsigned int* __restrict__ C,                                              \
+    int M, int N, int K                                                        \
+) {                                                                            \
+    const int BLOCK_SIZE_M = 64;                                               \
+    const int BLOCK_SIZE_K = 32;                                               \
+    const int BLOCK_SIZE_N = 64;                                               \
+    const int THREAD_SIZE_M = 4;                                               \
+    const int THREAD_SIZE_N = 4;                                               \
+                                                                               \
+    const int bszm = BLOCK_SIZE_M / THREAD_SIZE_M;                             \
+    const int bszn = BLOCK_SIZE_N / THREAD_SIZE_N;                             \
+    const int THREAD_NUM_PER_BLOCK = bszm * bszn;                              \
+                                                                               \
+    int DIM_GRID_X = (M + BLOCK_SIZE_M - 1) / BLOCK_SIZE_M;                    \
+    int DIM_GRID_Y = (N + BLOCK_SIZE_N - 1) / BLOCK_SIZE_N;                    \
+    int BLOCK_IDX = blockIdx.x % DIM_GRID_X;                                   \
+    int BLOCK_IDY = blockIdx.x / DIM_GRID_X;                                   \
+                                                                               \
+    const int tid = threadIdx.y * bszm + threadIdx.x;                          \
+                                                                               \
+    __shared__ unsigned int As[BLOCK_SIZE_M * BLOCK_SIZE_K];                   \
+    __shared__ unsigned int Bs[BLOCK_SIZE_K * BLOCK_SIZE_N];                   \
+                                                                               \
+    unsigned int accum[THREAD_SIZE_M * THREAD_SIZE_N];                         \
+    unsigned int regs_a[THREAD_SIZE_M];                                        \
+    unsigned int regs_b[THREAD_SIZE_N];                                        \
+                                                                               \
+    _Pragma("unroll")                                                          \
+    for (int i = 0; i < THREAD_SIZE_M * THREAD_SIZE_N; ++i) {                  \
+        accum[i] = INIT_VAL;                                                   \
+    }                                                                          \
+                                                                               \
+    const int A_TILE_COL = tid / BLOCK_SIZE_M;                                 \
+    const int A_TILE_ROW = tid % BLOCK_SIZE_M;                                 \
+    const int B_TILE_COL = tid / BLOCK_SIZE_K;                                 \
+    const int B_TILE_ROW = tid % BLOCK_SIZE_K;                                 \
+    const int A_TILE_COL_STRIDE = THREAD_NUM_PER_BLOCK / BLOCK_SIZE_M;         \
+    const int B_TILE_COL_STRIDE = THREAD_NUM_PER_BLOCK / BLOCK_SIZE_K;         \
+                                                                               \
+    for (int tile_idx = 0; tile_idx < K; tile_idx += BLOCK_SIZE_K) {           \
+        LOAD_A_TILE(A, INIT_VAL)                                          \
+                                                                               \
+        LOAD_B_TILE(B, INIT_VAL)                                          \
+                                                                               \
+        __syncthreads();                                                       \
+                                                                               \
+        _Pragma("unroll")                                                      \
+        for (int k = 0; k < BLOCK_SIZE_K; ++k) {                               \
+            _Pragma("unroll")                                                  \
+            for (int tm = 0; tm < THREAD_SIZE_M; ++tm) {                       \
+                regs_a[tm] = As[OFFSET_COL(threadIdx.x * THREAD_SIZE_M + tm,   \
+                                           k, BLOCK_SIZE_M)];                  \
+            }                                                                  \
+            _Pragma("unroll")                                                  \
+            for (int tn = 0; tn < THREAD_SIZE_N; ++tn) {                       \
+                regs_b[tn] = Bs[OFFSET_COL(k, threadIdx.y * THREAD_SIZE_N + tn,\
+                                           BLOCK_SIZE_K)];                     \
+            }                                                                  \
+            _Pragma("unroll")                                                  \
+            for (int tm = 0; tm < THREAD_SIZE_M; ++tm) {                       \
+                _Pragma("unroll")                                              \
+                for (int tn = 0; tn < THREAD_SIZE_N; ++tn) {                   \
+                    int idx = OFFSET_COL(tm, tn, THREAD_SIZE_M);               \
+                    accum[idx] = COMPARE_FN(MUL_FN(regs_a[tm], regs_b[tn]),    \
+                                            accum[idx]);                       \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+        __syncthreads();                                                       \
+    }                                                                          \
+                                                                               \
+        STORE_C_TILE(C)                                                   \
+}
+
+// ============================================================================
+// U64 GEMM KERNEL MACRO (Bitwise semiring, 64 lanes)
+// ============================================================================
+// Identical tiling to I64 (32x16x32, 4x4) on an 8-byte `unsigned long long`.
+
+#define TROPICAL_GEMM_U64(KERNEL_NAME, INIT_VAL, COMPARE_FN, MUL_FN)            \
+extern "C" __global__ void KERNEL_NAME(                                        \
+    const unsigned long long* __restrict__ A,                                  \
+    const unsigned long long* __restrict__ B,                                  \
+    unsigned long long* __restrict__ C,                                        \
+    int M, int N, int K                                                        \
+) {                                                                            \
+    const int BLOCK_SIZE_M = 32;                                               \
+    const int BLOCK_SIZE_K = 16;                                               \
+    const int BLOCK_SIZE_N = 32;                                               \
+    const int THREAD_SIZE_M = 4;                                               \
+    const int THREAD_SIZE_N = 4;                                               \
+                                                                               \
+    const int bszm = BLOCK_SIZE_M / THREAD_SIZE_M;                             \
+    const int bszn = BLOCK_SIZE_N / THREAD_SIZE_N;                             \
+    const int THREAD_NUM_PER_BLOCK = bszm * bszn;                              \
+                                                                               \
+    int DIM_GRID_X = (M + BLOCK_SIZE_M - 1) / BLOCK_SIZE_M;                    \
+    int DIM_GRID_Y = (N + BLOCK_SIZE_N - 1) / BLOCK_SIZE_N;                    \
+    int BLOCK_IDX = blockIdx.x % DIM_GRID_X;                                   \
+    int BLOCK_IDY = blockIdx.x / DIM_GRID_X;                                   \
+                                                                               \
+    const int tid = threadIdx.y * bszm + threadIdx.x;                          \
+                                                                               \
+    __shared__ unsigned long long As[BLOCK_SIZE_M * BLOCK_SIZE_K];             \
+    __shared__ unsigned long long Bs[BLOCK_SIZE_K * BLOCK_SIZE_N];             \
+                                                                               \
+    unsigned long long accum[THREAD_SIZE_M * THREAD_SIZE_N];                   \
+    unsigned long long regs_a[THREAD_SIZE_M];                                  \
+    unsigned long long regs_b[THREAD_SIZE_N];                                  \
                                                                                \
     _Pragma("unroll")                                                          \
     for (int i = 0; i < THREAD_SIZE_M * THREAD_SIZE_N; ++i) {                  \
@@ -1055,6 +1233,10 @@ TROPICAL_GEMM_I64(tropical_maxmul_i64_nn,  0LL,         max_i64, mul_i64)
 
 // --- BOOL Basic GEMM Kernel (AndOr semiring) ---
 TROPICAL_GEMM_BOOL(tropical_andor_bool_nn, false, or_bool, and_bool)
+
+// --- U32/U64 Bitwise GEMM Kernels (bit-packed boolean) ---
+TROPICAL_GEMM_U32(tropical_bitwise_u32_nn, 0u,   or_u32, and_u32)
+TROPICAL_GEMM_U64(tropical_bitwise_u64_nn, 0ull, or_u64, and_u64)
 
 // --- I32 GEMM with Argmax Kernels ---
 // ZERO_FN canonicalizes a drifted tropical-zero cell's argmax to 0 at write-out.

--- a/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
+++ b/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
@@ -1357,3 +1357,76 @@ extern "C" __global__ void KERNEL_NAME(                                        \
 TROPICAL_GEMM_BATCHED_ARGMAX_F32(tropical_maxplus_f32_nn_batched_with_argmax, NEG_INF_F32, >, +)
 TROPICAL_GEMM_BATCHED_ARGMAX_F32(tropical_minplus_f32_nn_batched_with_argmax, INF_F32,     <, +)
 TROPICAL_GEMM_BATCHED_ARGMAX_F32(tropical_maxmul_f32_nn_batched_with_argmax,  0.0f,        >, *)
+
+// ============================================================================
+// K-PACKED BOOLEAN (AndOr) GEMM — pack the contraction dim K into 32-bit words
+// ============================================================================
+// Distinct from the byte AndOr kernel and from TropicalBitwise (which packs the
+// problem axis). Here we pack the *contraction* axis of a single boolean matmul:
+//   C[i,j] = OR_k (A[i,k] AND B[k,j])  ==  any_w( Apacked(i,w) & Bpacked(j,w) )
+// Column-major throughout. Kw = ceil(K/32). Bit b of word w holds K-element 32*w+b
+// (LSB-first). Tail bits (32*w+b >= K) are explicitly zeroed; 0 is AND's absorbing
+// element, so padding lanes are inert and the GEMM K-loop is branchless.
+
+// Pack A (M×K col-major bool) -> Apacked (M×Kw col-major u32). One thread per (i,w).
+extern "C" __global__ void pack_rows_u32(
+    const bool* __restrict__ A,
+    unsigned int* __restrict__ Apacked,
+    int M, int K)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;   // row of A
+    int w = blockIdx.y * blockDim.y + threadIdx.y;   // output word index
+    int Kw = K / 32 + (K % 32 != 0);   // == ceil(K/32) without (K+31) overflow near INT_MAX
+    if (i >= M || w >= Kw) return;
+    unsigned int word = 0u;
+    #pragma unroll
+    for (int b = 0; b < 32; ++b) {
+        int k = 32 * w + b;
+        if (k < K) {
+            // static_cast<unsigned> BEFORE the shift: a high-bit shift of a
+            // promoted `bool`/`int` would be signed; the cast keeps it well-defined.
+            word |= static_cast<unsigned int>(A[(size_t)k * M + i]) << b;
+        }
+    }
+    Apacked[(size_t)w * M + i] = word;
+}
+
+// Pack B (K×N col-major bool) -> Bpacked (Kw×N col-major u32). One thread per (j,w).
+extern "C" __global__ void pack_cols_u32(
+    const bool* __restrict__ B,
+    unsigned int* __restrict__ Bpacked,
+    int N, int K)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;   // column of B
+    int w = blockIdx.y * blockDim.y + threadIdx.y;   // output word index
+    int Kw = K / 32 + (K % 32 != 0);   // == ceil(K/32) without (K+31) overflow near INT_MAX
+    if (j >= N || w >= Kw) return;
+    unsigned int word = 0u;
+    #pragma unroll
+    for (int b = 0; b < 32; ++b) {
+        int k = 32 * w + b;
+        if (k < K) {
+            word |= static_cast<unsigned int>(B[(size_t)j * K + k]) << b;
+        }
+    }
+    Bpacked[(size_t)j * Kw + w] = word;
+}
+
+// Direct K-packed GEMM: one thread per output cell C[i,j]. No shared memory and no
+// barrier, so the `acc == 0` early-exit is correct here (it is NOT valid in a tiled
+// kernel). Apacked is M×Kw col-major, Bpacked is Kw×N col-major, C is M×N col-major.
+extern "C" __global__ void tropical_andor_kpack_direct_u32(
+    const unsigned int* __restrict__ Apacked,
+    const unsigned int* __restrict__ Bpacked,
+    bool* __restrict__ C,
+    int M, int N, int Kw)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;   // row
+    int j = blockIdx.y * blockDim.y + threadIdx.y;   // column
+    if (i >= M || j >= N) return;
+    unsigned int acc = 0u;
+    for (int w = 0; w < Kw && acc == 0u; ++w) {
+        acc |= Apacked[(size_t)w * M + i] & Bpacked[(size_t)j * Kw + w];
+    }
+    C[(size_t)j * M + i] = (acc != 0u);
+}

--- a/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
+++ b/crates/tropical-gemm-cuda/kernels/tropical_gemm.cu
@@ -67,6 +67,17 @@ __device__ __forceinline__ long long mul_i64(long long a, long long b) {
     return a * b;
 }
 
+// Boolean (AndOr) semiring: add = OR, mul = AND, zero = false, one = true.
+// false is a true absorbing zero (false AND x = false), so no sentinel/drift like
+// the integer MaxPlus types -- the out-of-range tile PAD is simply false.
+//
+// Use *bitwise* &/| (not logical &&/||): for 0/1 bytes they are equivalent, but
+// bitwise ops let ptxas keep the values in byte/integer form (LOP3) instead of
+// round-tripping each byte through a predicate (ISETP -> PLOP3 -> P2R), which
+// measured ~1.6x slower than the reference's fused byte-wise path on sm_86.
+__device__ __forceinline__ bool or_bool(bool a, bool b)  { return a | b; }
+__device__ __forceinline__ bool and_bool(bool a, bool b) { return a & b; }
+
 // Drifted tropical-zero detection for argmax canonicalization. A no-contribution
 // output cell's value sits in "infinity territory" (past S/2) after the
 // guard-free add drifts it (`S + data`). Used ONLY at the O(M*N) write-out (not
@@ -434,6 +445,92 @@ extern "C" __global__ void KERNEL_NAME(                                        \
                     int prod = MUL_FN(regs_a[tm], regs_b[tn]);                  \
                     int idx = OFFSET_COL(tm, tn, THREAD_SIZE_M);               \
                     accum[idx] = COMPARE_FN(accum[idx], prod);                 \
+                }                                                              \
+            }                                                                  \
+        }                                                                      \
+        __syncthreads();                                                       \
+    }                                                                          \
+                                                                               \
+        STORE_C_TILE(C)                                                   \
+}
+
+// ============================================================================
+// BOOL GEMM KERNEL MACRO (AndOr semiring)
+// ============================================================================
+// Identical tiling to I32 (64x32x64, 4x4 threads) but on a 1-byte `bool`
+// element. add = OR (COMPARE_FN), mul = AND (MUL_FN), tropical zero = false.
+// A 1-byte element uses *less* shared memory than i32, so the block config is
+// safe. false absorbs in AND/OR, so the out-of-range PAD is just INIT_VAL.
+
+#define TROPICAL_GEMM_BOOL(KERNEL_NAME, INIT_VAL, COMPARE_FN, MUL_FN)           \
+extern "C" __global__ void KERNEL_NAME(                                        \
+    const bool* __restrict__ A,                                                \
+    const bool* __restrict__ B,                                                \
+    bool* __restrict__ C,                                                      \
+    int M, int N, int K                                                        \
+) {                                                                            \
+    const int BLOCK_SIZE_M = 64;                                               \
+    const int BLOCK_SIZE_K = 32;                                               \
+    const int BLOCK_SIZE_N = 64;                                               \
+    const int THREAD_SIZE_M = 4;                                               \
+    const int THREAD_SIZE_N = 4;                                               \
+                                                                               \
+    const int bszm = BLOCK_SIZE_M / THREAD_SIZE_M;                             \
+    const int bszn = BLOCK_SIZE_N / THREAD_SIZE_N;                             \
+    const int THREAD_NUM_PER_BLOCK = bszm * bszn;                              \
+                                                                               \
+    int DIM_GRID_X = (M + BLOCK_SIZE_M - 1) / BLOCK_SIZE_M;                    \
+    int DIM_GRID_Y = (N + BLOCK_SIZE_N - 1) / BLOCK_SIZE_N;                    \
+    int BLOCK_IDX = blockIdx.x % DIM_GRID_X;                                   \
+    int BLOCK_IDY = blockIdx.x / DIM_GRID_X;                                   \
+                                                                               \
+    const int tid = threadIdx.y * bszm + threadIdx.x;                          \
+                                                                               \
+    __shared__ bool As[BLOCK_SIZE_M * BLOCK_SIZE_K];                           \
+    __shared__ bool Bs[BLOCK_SIZE_K * BLOCK_SIZE_N];                           \
+                                                                               \
+    bool accum[THREAD_SIZE_M * THREAD_SIZE_N];                                 \
+    bool regs_a[THREAD_SIZE_M];                                                \
+    bool regs_b[THREAD_SIZE_N];                                                \
+                                                                               \
+    _Pragma("unroll")                                                          \
+    for (int i = 0; i < THREAD_SIZE_M * THREAD_SIZE_N; ++i) {                  \
+        accum[i] = INIT_VAL;                                                   \
+    }                                                                          \
+                                                                               \
+    const int A_TILE_COL = tid / BLOCK_SIZE_M;                                 \
+    const int A_TILE_ROW = tid % BLOCK_SIZE_M;                                 \
+    const int B_TILE_COL = tid / BLOCK_SIZE_K;                                 \
+    const int B_TILE_ROW = tid % BLOCK_SIZE_K;                                 \
+    const int A_TILE_COL_STRIDE = THREAD_NUM_PER_BLOCK / BLOCK_SIZE_M;         \
+    const int B_TILE_COL_STRIDE = THREAD_NUM_PER_BLOCK / BLOCK_SIZE_K;         \
+                                                                               \
+    for (int tile_idx = 0; tile_idx < K; tile_idx += BLOCK_SIZE_K) {           \
+        LOAD_A_TILE(A, INIT_VAL)                                          \
+                                                                               \
+        LOAD_B_TILE(B, INIT_VAL)                                          \
+                                                                               \
+        __syncthreads();                                                       \
+                                                                               \
+        _Pragma("unroll")                                                      \
+        for (int k = 0; k < BLOCK_SIZE_K; ++k) {                               \
+            _Pragma("unroll")                                                  \
+            for (int tm = 0; tm < THREAD_SIZE_M; ++tm) {                       \
+                regs_a[tm] = As[OFFSET_COL(threadIdx.x * THREAD_SIZE_M + tm,   \
+                                           k, BLOCK_SIZE_M)];                  \
+            }                                                                  \
+            _Pragma("unroll")                                                  \
+            for (int tn = 0; tn < THREAD_SIZE_N; ++tn) {                       \
+                regs_b[tn] = Bs[OFFSET_COL(k, threadIdx.y * THREAD_SIZE_N + tn,\
+                                           BLOCK_SIZE_K)];                     \
+            }                                                                  \
+            _Pragma("unroll")                                                  \
+            for (int tm = 0; tm < THREAD_SIZE_M; ++tm) {                       \
+                _Pragma("unroll")                                              \
+                for (int tn = 0; tn < THREAD_SIZE_N; ++tn) {                   \
+                    int idx = OFFSET_COL(tm, tn, THREAD_SIZE_M);               \
+                    accum[idx] = COMPARE_FN(MUL_FN(regs_a[tm], regs_b[tn]),    \
+                                            accum[idx]);                       \
                 }                                                              \
             }                                                                  \
         }                                                                      \
@@ -955,6 +1052,9 @@ TROPICAL_GEMM_I32(tropical_maxmul_i32_nn,  0,           max_i32, mul_i32)
 TROPICAL_GEMM_I64(tropical_maxplus_i64_nn, NEG_INF_I64, max_i64, add_i64)
 TROPICAL_GEMM_I64(tropical_minplus_i64_nn, INF_I64,     min_i64, add_i64)
 TROPICAL_GEMM_I64(tropical_maxmul_i64_nn,  0LL,         max_i64, mul_i64)
+
+// --- BOOL Basic GEMM Kernel (AndOr semiring) ---
+TROPICAL_GEMM_BOOL(tropical_andor_bool_nn, false, or_bool, and_bool)
 
 // --- I32 GEMM with Argmax Kernels ---
 // ZERO_FN canonicalizes a drifted tropical-zero cell's argmax to 0 at write-out.

--- a/crates/tropical-gemm-cuda/src/context.rs
+++ b/crates/tropical-gemm-cuda/src/context.rs
@@ -40,6 +40,9 @@ const KERNEL_NAMES: &[&str] = &[
     "tropical_maxmul_i64_nn",
     // Standard GEMM kernel (bool / AndOr semiring)
     "tropical_andor_bool_nn",
+    // Standard GEMM kernels (u32/u64 / Bitwise semiring)
+    "tropical_bitwise_u32_nn",
+    "tropical_bitwise_u64_nn",
     // GEMM with argmax kernels (f32)
     "tropical_maxplus_f32_nn_with_argmax",
     "tropical_minplus_f32_nn_with_argmax",

--- a/crates/tropical-gemm-cuda/src/context.rs
+++ b/crates/tropical-gemm-cuda/src/context.rs
@@ -38,6 +38,8 @@ const KERNEL_NAMES: &[&str] = &[
     "tropical_maxplus_i64_nn",
     "tropical_minplus_i64_nn",
     "tropical_maxmul_i64_nn",
+    // Standard GEMM kernel (bool / AndOr semiring)
+    "tropical_andor_bool_nn",
     // GEMM with argmax kernels (f32)
     "tropical_maxplus_f32_nn_with_argmax",
     "tropical_minplus_f32_nn_with_argmax",

--- a/crates/tropical-gemm-cuda/src/context.rs
+++ b/crates/tropical-gemm-cuda/src/context.rs
@@ -43,6 +43,10 @@ const KERNEL_NAMES: &[&str] = &[
     // Standard GEMM kernels (u32/u64 / Bitwise semiring)
     "tropical_bitwise_u32_nn",
     "tropical_bitwise_u64_nn",
+    // K-packed AndOr GEMM (pack contraction dim K into u32 words)
+    "pack_rows_u32",
+    "pack_cols_u32",
+    "tropical_andor_kpack_direct_u32",
     // GEMM with argmax kernels (f32)
     "tropical_maxplus_f32_nn_with_argmax",
     "tropical_minplus_f32_nn_with_argmax",

--- a/crates/tropical-gemm-cuda/src/kernels.rs
+++ b/crates/tropical-gemm-cuda/src/kernels.rs
@@ -7,7 +7,8 @@ use crate::memory::{
 };
 use cudarc::driver::{DeviceRepr, LaunchConfig, PushKernelArg, ValidAsZeroBits};
 use tropical_gemm::types::{
-    TropicalAndOr, TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring,
+    TropicalAndOr, TropicalBitwise, TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus,
+    TropicalSemiring,
 };
 
 /// Trait for types that can be computed on GPU.
@@ -212,6 +213,60 @@ macro_rules! impl_cuda_kernel_bool {
 
 impl_cuda_kernel_bool! {
     TropicalAndOr => "tropical_andor_bool_nn",
+}
+
+/// Macro to implement CudaKernel for u32 types (Bitwise semiring).
+/// 4-byte element reuses the f32 grid/block helpers, exactly as i32 does.
+macro_rules! impl_cuda_kernel_u32 {
+    ($($semiring:ty => $kernel_name:literal),* $(,)?) => {
+        $(
+            impl CudaKernel for $semiring {
+                const KERNEL_NAME: &'static str = $kernel_name;
+
+                fn launch_gemm(
+                    ctx: &CudaContext,
+                    a: &GpuMatrix<u32>,
+                    b: &GpuMatrix<u32>,
+                    c: &mut GpuMatrix<u32>,
+                ) -> Result<()> {
+                    let grid = CudaContext::grid_dims_f32(a.rows(), b.cols());
+                    let block = CudaContext::block_dims_f32();
+                    launch_kernel_impl(ctx, Self::KERNEL_NAME, a, b, c, grid, block)
+                }
+            }
+        )*
+    };
+}
+
+/// Macro to implement CudaKernel for u64 types (Bitwise semiring).
+/// 8-byte element reuses the f64 grid/block helpers, exactly as i64 does.
+macro_rules! impl_cuda_kernel_u64 {
+    ($($semiring:ty => $kernel_name:literal),* $(,)?) => {
+        $(
+            impl CudaKernel for $semiring {
+                const KERNEL_NAME: &'static str = $kernel_name;
+
+                fn launch_gemm(
+                    ctx: &CudaContext,
+                    a: &GpuMatrix<u64>,
+                    b: &GpuMatrix<u64>,
+                    c: &mut GpuMatrix<u64>,
+                ) -> Result<()> {
+                    let grid = CudaContext::grid_dims_f64(a.rows(), b.cols());
+                    let block = CudaContext::block_dims_f64();
+                    launch_kernel_impl(ctx, Self::KERNEL_NAME, a, b, c, grid, block)
+                }
+            }
+        )*
+    };
+}
+
+impl_cuda_kernel_u32! {
+    TropicalBitwise<u32> => "tropical_bitwise_u32_nn",
+}
+
+impl_cuda_kernel_u64! {
+    TropicalBitwise<u64> => "tropical_bitwise_u64_nn",
 }
 
 // ============================================================================

--- a/crates/tropical-gemm-cuda/src/kernels.rs
+++ b/crates/tropical-gemm-cuda/src/kernels.rs
@@ -6,7 +6,9 @@ use crate::memory::{
     ExternalGpuMatrix, ExternalGpuTensor3, GpuMatrix, GpuMatrixWithArgmax, GpuTensor3WithArgmax,
 };
 use cudarc::driver::{DeviceRepr, LaunchConfig, PushKernelArg, ValidAsZeroBits};
-use tropical_gemm::types::{TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring};
+use tropical_gemm::types::{
+    TropicalAndOr, TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring,
+};
 
 /// Trait for types that can be computed on GPU.
 pub trait CudaKernel: TropicalSemiring
@@ -182,6 +184,34 @@ impl_cuda_kernel_i64! {
     TropicalMaxPlus<i64> => "tropical_maxplus_i64_nn",
     TropicalMinPlus<i64> => "tropical_minplus_i64_nn",
     TropicalMaxMul<i64> => "tropical_maxmul_i64_nn",
+}
+
+/// Macro to implement CudaKernel for the bool (AndOr) semiring.
+/// A 1-byte element reuses the f32 grid/block helpers (64x64 tile), exactly as
+/// i32 does — the smaller element only reduces shared-memory use.
+macro_rules! impl_cuda_kernel_bool {
+    ($($semiring:ty => $kernel_name:literal),* $(,)?) => {
+        $(
+            impl CudaKernel for $semiring {
+                const KERNEL_NAME: &'static str = $kernel_name;
+
+                fn launch_gemm(
+                    ctx: &CudaContext,
+                    a: &GpuMatrix<bool>,
+                    b: &GpuMatrix<bool>,
+                    c: &mut GpuMatrix<bool>,
+                ) -> Result<()> {
+                    let grid = CudaContext::grid_dims_f32(a.rows(), b.cols());
+                    let block = CudaContext::block_dims_f32();
+                    launch_kernel_impl(ctx, Self::KERNEL_NAME, a, b, c, grid, block)
+                }
+            }
+        )*
+    };
+}
+
+impl_cuda_kernel_bool! {
+    TropicalAndOr => "tropical_andor_bool_nn",
 }
 
 // ============================================================================

--- a/crates/tropical-gemm-cuda/src/kpack.rs
+++ b/crates/tropical-gemm-cuda/src/kpack.rs
@@ -1,0 +1,403 @@
+//! K-packed Boolean (AndOr) GPU GEMM.
+//!
+//! Packs the *contraction* dimension K of a single boolean matmul into 32-bit
+//! words so the inner loop runs `acc |= (A_word & B_word)` over `Kw = ceil(K/32)`
+//! words instead of one `bool` byte per K-element. This is distinct from the byte
+//! `tropical_andor_bool_nn` kernel (kept as the default) and from `TropicalBitwise`
+//! (which packs the problem axis). Column-major throughout; bit `b` of word `w`
+//! holds K-element `32*w + b` (LSB-first); tail bits are zero (0 absorbs AND).
+//!
+//! See `docs/superpowers/specs/2026-06-01-andor-kpack-design.md`.
+
+use crate::context::CudaContext;
+use crate::error::{CudaError, Result};
+use crate::memory::GpuMatrix;
+use cudarc::driver::{LaunchConfig, PushKernelArg};
+
+/// Square thread-block edge for the pack and direct kernels (256 threads/block).
+const TILE: usize = 16;
+
+#[inline]
+fn ceil_div(a: usize, b: usize) -> u32 {
+    a.div_ceil(b) as u32
+}
+
+/// Convert a dimension to the `int` extent the CUDA kernels take, rejecting values
+/// that don't fit `i32` rather than silently truncating to a negative/garbage extent.
+/// Once every dimension is `<= i32::MAX`, the `m*k` products in `validate_gemm_input`
+/// also cannot overflow `usize` on a 64-bit target.
+fn dim_i32(label: &str, v: usize) -> Result<i32> {
+    i32::try_from(v).map_err(|_| {
+        CudaError::DimensionMismatch(format!("{label} ({v}) exceeds i32::MAX for CUDA kernels"))
+    })
+}
+
+/// Bit-packed left operand: logical M×Kw column-major `u32`, `Kw = ceil(K/32)`.
+/// Opaque so a row-packed operand can't be passed where a column-packed one is
+/// expected. Reusable across many GEMMs to amortize packing cost.
+pub struct AndOrPackedRows {
+    words: GpuMatrix<u32>, // M × Kw, column-major
+    m: usize,
+    k: usize,
+}
+
+/// Bit-packed right operand: logical Kw×N column-major `u32`, `Kw = ceil(K/32)`.
+pub struct AndOrPackedCols {
+    words: GpuMatrix<u32>, // Kw × N, column-major
+    k: usize,
+    n: usize,
+}
+
+impl AndOrPackedRows {
+    /// Logical rows (M) of the original `bool` operand.
+    pub fn rows(&self) -> usize {
+        self.m
+    }
+    /// Logical contraction dimension (K) of the original `bool` operand.
+    pub fn k(&self) -> usize {
+        self.k
+    }
+}
+
+impl AndOrPackedCols {
+    /// Logical contraction dimension (K) of the original `bool` operand.
+    pub fn k(&self) -> usize {
+        self.k
+    }
+    /// Logical columns (N) of the original `bool` operand.
+    pub fn cols(&self) -> usize {
+        self.n
+    }
+}
+
+/// Launch `pack_rows_u32` into a caller-provided `words` buffer (M×Kw u32). Split
+/// out from `pack_andor_rows_gpu` so a test can pack into a pre-dirtied buffer and
+/// confirm the tail bits are cleared (not merely left zero by `alloc`).
+fn launch_pack_rows(
+    ctx: &CudaContext,
+    a: &GpuMatrix<bool>,
+    words: &mut GpuMatrix<u32>,
+    m: usize,
+    k: usize,
+) -> Result<()> {
+    let kw = k.div_ceil(32);
+    let kernel = ctx.get_kernel("pack_rows_u32")?;
+    let cfg = LaunchConfig {
+        grid_dim: (ceil_div(m, TILE), ceil_div(kw, TILE), 1),
+        block_dim: (TILE as u32, TILE as u32, 1),
+        shared_mem_bytes: 0,
+    };
+    let m_i32 = dim_i32("M", m)?;
+    let k_i32 = dim_i32("K", k)?;
+    let stream = ctx.stream();
+    let mut builder = stream.launch_builder(&kernel);
+    builder
+        .arg(a.as_slice())
+        .arg(words.as_slice_mut())
+        .arg(&m_i32)
+        .arg(&k_i32);
+    unsafe {
+        builder.launch(cfg)?;
+    }
+    stream.synchronize()?;
+    Ok(())
+}
+
+/// Launch `pack_cols_u32` into a caller-provided `words` buffer (Kw×N u32).
+fn launch_pack_cols(
+    ctx: &CudaContext,
+    b: &GpuMatrix<bool>,
+    words: &mut GpuMatrix<u32>,
+    n: usize,
+    k: usize,
+) -> Result<()> {
+    let kw = k.div_ceil(32);
+    let kernel = ctx.get_kernel("pack_cols_u32")?;
+    let cfg = LaunchConfig {
+        grid_dim: (ceil_div(n, TILE), ceil_div(kw, TILE), 1),
+        block_dim: (TILE as u32, TILE as u32, 1),
+        shared_mem_bytes: 0,
+    };
+    let n_i32 = dim_i32("N", n)?;
+    let k_i32 = dim_i32("K", k)?;
+    let stream = ctx.stream();
+    let mut builder = stream.launch_builder(&kernel);
+    builder
+        .arg(b.as_slice())
+        .arg(words.as_slice_mut())
+        .arg(&n_i32)
+        .arg(&k_i32);
+    unsafe {
+        builder.launch(cfg)?;
+    }
+    stream.synchronize()?;
+    Ok(())
+}
+
+/// Pack a column-major `bool` matrix A (M×K) into `AndOrPackedRows` (M×Kw u32) on GPU.
+pub fn pack_andor_rows_gpu(ctx: &CudaContext, a: &GpuMatrix<bool>) -> Result<AndOrPackedRows> {
+    let m = a.rows();
+    let k = a.cols();
+    if m == 0 || k == 0 {
+        return Err(CudaError::DimensionMismatch(format!(
+            "pack_andor_rows_gpu: zero dimension (M={m}, K={k})"
+        )));
+    }
+    let kw = k.div_ceil(32);
+    let mut words = GpuMatrix::<u32>::alloc(ctx, m, kw)?;
+    launch_pack_rows(ctx, a, &mut words, m, k)?;
+    Ok(AndOrPackedRows { words, m, k })
+}
+
+/// Pack a column-major `bool` matrix B (K×N) into `AndOrPackedCols` (Kw×N u32) on GPU.
+pub fn pack_andor_cols_gpu(ctx: &CudaContext, b: &GpuMatrix<bool>) -> Result<AndOrPackedCols> {
+    let k = b.rows();
+    let n = b.cols();
+    if k == 0 || n == 0 {
+        return Err(CudaError::DimensionMismatch(format!(
+            "pack_andor_cols_gpu: zero dimension (K={k}, N={n})"
+        )));
+    }
+    let kw = k.div_ceil(32);
+    let mut words = GpuMatrix::<u32>::alloc(ctx, kw, n)?;
+    launch_pack_cols(ctx, b, &mut words, n, k)?;
+    Ok(AndOrPackedCols { words, k, n })
+}
+
+/// GPU-resident K-packed AndOr GEMM: `C[i,j] = any_w(A_word(i,w) & B_word(j,w))`.
+/// Reuse the packed operands across many calls to amortize packing.
+pub fn tropical_gemm_gpu_andor_packed(
+    ctx: &CudaContext,
+    a: &AndOrPackedRows,
+    b: &AndOrPackedCols,
+    c: &mut GpuMatrix<bool>,
+) -> Result<()> {
+    if a.k != b.k {
+        return Err(CudaError::DimensionMismatch(format!(
+            "A.k ({}) != B.k ({})",
+            a.k, b.k
+        )));
+    }
+    if c.rows() != a.m || c.cols() != b.n {
+        return Err(CudaError::DimensionMismatch(format!(
+            "C dimensions ({}, {}) don't match A×B ({}, {})",
+            c.rows(),
+            c.cols(),
+            a.m,
+            b.n
+        )));
+    }
+    let m = a.m;
+    let n = b.n;
+    let kw = a.k.div_ceil(32);
+
+    let kernel = ctx.get_kernel("tropical_andor_kpack_direct_u32")?;
+    let cfg = LaunchConfig {
+        grid_dim: (ceil_div(m, TILE), ceil_div(n, TILE), 1),
+        block_dim: (TILE as u32, TILE as u32, 1),
+        shared_mem_bytes: 0,
+    };
+    let m_i32 = dim_i32("M", m)?;
+    let n_i32 = dim_i32("N", n)?;
+    let kw_i32 = dim_i32("Kw", kw)?;
+    let stream = ctx.stream();
+    let mut builder = stream.launch_builder(&kernel);
+    builder
+        .arg(a.words.as_slice())
+        .arg(b.words.as_slice())
+        .arg(c.as_slice_mut())
+        .arg(&m_i32)
+        .arg(&n_i32)
+        .arg(&kw_i32);
+    unsafe {
+        builder.launch(cfg)?;
+    }
+    stream.synchronize()?;
+    Ok(())
+}
+
+/// One-shot K-packed AndOr GEMM: upload → pack → gemm → download. bool in / bool out.
+///
+/// `a` is column-major M×K, `b` is column-major K×N, result is column-major M×N.
+/// Unlike `validate_gemm_input` (slice-length only), this **rejects zero dimensions**:
+/// `Kw = 0` / empty operands are degenerate for packing.
+pub fn tropical_matmul_gpu_andor_packed(
+    a: &[bool],
+    m: usize,
+    k: usize,
+    b: &[bool],
+    n: usize,
+) -> Result<Vec<bool>> {
+    // Reject zero and over-`i32` dims BEFORE `validate_gemm_input` (which multiplies
+    // `m*k` / `k*n` unchecked): once each dim fits `i32`, those products fit `usize`.
+    if m == 0 || k == 0 || n == 0 {
+        return Err(CudaError::DimensionMismatch(format!(
+            "K-packed AndOr GEMM requires non-zero dimensions (M={m}, K={k}, N={n})"
+        )));
+    }
+    dim_i32("M", m)?;
+    dim_i32("K", k)?;
+    dim_i32("N", n)?;
+    crate::validate_gemm_input(a, b, m, k, n)?;
+
+    let ctx = crate::get_global_context()?;
+    let a_gpu = GpuMatrix::from_host(ctx, a, m, k)?;
+    let b_gpu = GpuMatrix::from_host(ctx, b, k, n)?;
+
+    let packed_a = pack_andor_rows_gpu(ctx, &a_gpu)?;
+    let packed_b = pack_andor_cols_gpu(ctx, &b_gpu)?;
+
+    let mut c_gpu = GpuMatrix::<bool>::alloc(ctx, m, n)?;
+    tropical_gemm_gpu_andor_packed(ctx, &packed_a, &packed_b, &mut c_gpu)?;
+    c_gpu.to_host(ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CudaContext;
+
+    /// Skip helper (kpack.rs can't see lib.rs's `cuda_context_or_skip`).
+    fn ctx_or_skip() -> Option<&'static CudaContext> {
+        match std::panic::catch_unwind(crate::get_global_context) {
+            Ok(Ok(ctx)) => Some(ctx),
+            _ => {
+                println!("CUDA not available, skipping test");
+                None
+            }
+        }
+    }
+
+    /// Reference row packer (oracle). A is M×K column-major bool; returns Apacked
+    /// M×Kw column-major u32 with `Apacked[w*M + i]`, bit `b` = `A[(32*w+b)*M + i]`.
+    fn reference_pack_rows(a: &[bool], m: usize, k: usize) -> Vec<u32> {
+        let kw = k.div_ceil(32);
+        let mut out = vec![0u32; m * kw];
+        for i in 0..m {
+            for w in 0..kw {
+                let mut word = 0u32;
+                for b in 0..32 {
+                    let kk = 32 * w + b;
+                    if kk < k && a[kk * m + i] {
+                        word |= 1u32 << b;
+                    }
+                }
+                out[w * m + i] = word;
+            }
+        }
+        out
+    }
+
+    /// Reference column packer (oracle). B is K×N column-major bool; returns Bpacked
+    /// Kw×N column-major u32 with `Bpacked[j*Kw + w]`, bit `b` = `B[j*K + (32*w+b)]`.
+    fn reference_pack_cols(b: &[bool], n: usize, k: usize) -> Vec<u32> {
+        let kw = k.div_ceil(32);
+        let mut out = vec![0u32; kw * n];
+        for j in 0..n {
+            for w in 0..kw {
+                let mut word = 0u32;
+                for bit in 0..32 {
+                    let kk = 32 * w + bit;
+                    if kk < k && b[j * k + kk] {
+                        word |= 1u32 << bit;
+                    }
+                }
+                out[j * kw + w] = word;
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn reference_pack_rows_lsb_first_and_tail_zero() {
+        // M=1, K=33: one column of 33 bools. Set k=0 (bit 0 of word 0),
+        // k=31 (bit 31 of word 0), k=32 (bit 0 of word 1). Kw=2.
+        let mut a = vec![false; 33];
+        a[0] = true;
+        a[31] = true;
+        a[32] = true;
+        let packed = reference_pack_rows(&a, 1, 33);
+        assert_eq!(packed.len(), 2, "Kw=ceil(33/32)=2 words for M=1");
+        assert_eq!(packed[0], (1u32 << 0) | (1u32 << 31), "word 0: bits 0 and 31");
+        // Word 1 holds only k=32 in bit 0; bits 1..32 are tail (k>=33) and must be 0.
+        assert_eq!(packed[1], 1u32 << 0, "word 1: bit 0 set, tail bits zero");
+    }
+
+    #[test]
+    fn reference_pack_cols_lsb_first_and_tail_zero() {
+        // N=1, K=33 mirror of the rows test. B column is contiguous (stride 1).
+        let mut b = vec![false; 33];
+        b[0] = true;
+        b[31] = true;
+        b[32] = true;
+        let packed = reference_pack_cols(&b, 1, 33);
+        assert_eq!(packed.len(), 2);
+        assert_eq!(packed[0], (1u32 << 0) | (1u32 << 31));
+        assert_eq!(packed[1], 1u32 << 0);
+    }
+
+    #[test]
+    fn gpu_pack_rows_matches_reference() {
+        let Some(ctx) = ctx_or_skip() else { return };
+        // Spec K-set; M chosen non-tile-aligned to exercise the bounds guard.
+        for &k in &[1usize, 31, 32, 33, 63, 64, 65] {
+            let m = 5;
+            let a: Vec<bool> = (0..m * k).map(|i| (i * 7 + 1) % 3 == 0).collect();
+            let a_gpu = GpuMatrix::from_host(ctx, &a, m, k).unwrap();
+            let packed = pack_andor_rows_gpu(ctx, &a_gpu).unwrap();
+            let got = packed.words.to_host(ctx).unwrap();
+            let expected = reference_pack_rows(&a, m, k);
+            assert_eq!(got, expected, "GPU pack_rows != reference at K={k}");
+        }
+    }
+
+    #[test]
+    fn gpu_pack_cols_matches_reference() {
+        let Some(ctx) = ctx_or_skip() else { return };
+        for &k in &[1usize, 31, 32, 33, 63, 64, 65] {
+            let n = 6;
+            let b: Vec<bool> = (0..k * n).map(|i| (i * 5 + 2) % 4 == 0).collect();
+            let b_gpu = GpuMatrix::from_host(ctx, &b, k, n).unwrap();
+            let packed = pack_andor_cols_gpu(ctx, &b_gpu).unwrap();
+            let got = packed.words.to_host(ctx).unwrap();
+            let expected = reference_pack_cols(&b, n, k);
+            assert_eq!(got, expected, "GPU pack_cols != reference at K={k}");
+        }
+    }
+
+    #[test]
+    fn gpu_pack_rows_clears_tail_in_dirty_buffer() {
+        let Some(ctx) = ctx_or_skip() else { return };
+        // K=33 -> Kw=2; word 1 has only bit 0 valid, bits 1..32 are tail. Pack into a
+        // buffer pre-filled with all-ones: a packer that wrote only set bits (|=) would
+        // leave the tail dirty. Ours writes each word in full, so the tail must be 0.
+        let (m, k) = (3usize, 33usize);
+        let kw = k.div_ceil(32);
+        let a: Vec<bool> = (0..m * k).map(|i| i % 2 == 0).collect();
+        let a_gpu = GpuMatrix::from_host(ctx, &a, m, k).unwrap();
+        // Pre-dirty the words buffer with 0xFFFF_FFFF.
+        let dirty = vec![u32::MAX; m * kw];
+        let mut words = GpuMatrix::from_host(ctx, &dirty, m, kw).unwrap();
+        launch_pack_rows(ctx, &a_gpu, &mut words, m, k).unwrap();
+        let got = words.to_host(ctx).unwrap();
+        let expected = reference_pack_rows(&a, m, k);
+        assert_eq!(got, expected, "row pack: tail not cleared in dirty buffer");
+    }
+
+    #[test]
+    fn gpu_pack_cols_clears_tail_in_dirty_buffer() {
+        let Some(ctx) = ctx_or_skip() else { return };
+        // pack_cols_u32 is independent code from pack_rows_u32, so it needs its own
+        // dirty-buffer check. K=33 -> Kw=2; word 1's bits 1..32 are tail.
+        let (n, k) = (4usize, 33usize);
+        let kw = k.div_ceil(32);
+        let b: Vec<bool> = (0..k * n).map(|i| i % 3 == 0).collect();
+        let b_gpu = GpuMatrix::from_host(ctx, &b, k, n).unwrap();
+        let dirty = vec![u32::MAX; kw * n];
+        let mut words = GpuMatrix::from_host(ctx, &dirty, kw, n).unwrap();
+        launch_pack_cols(ctx, &b_gpu, &mut words, n, k).unwrap();
+        let got = words.to_host(ctx).unwrap();
+        let expected = reference_pack_cols(&b, n, k);
+        assert_eq!(got, expected, "col pack: tail not cleared in dirty buffer");
+    }
+}

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -2232,6 +2232,74 @@ mod tests {
     }
 
     #[test]
+    fn test_tropical_matmul_gpu_bitwise_u32() {
+        use tropical_gemm::types::TropicalBitwise;
+
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+
+        // Same 2x3 * 3x2 boolean problem as the AndOr test, but each u32 carries
+        // the boolean in bit 0 (a single populated lane). Column-major.
+        let a = vec![0x1u32, 0x0, 0x0, 0x0, 0x1, 0x0];
+        let b = vec![0x1u32, 0x1, 0x0, 0x0, 0x1, 0x1];
+
+        let c = tropical_matmul_gpu::<TropicalBitwise<u32>>(&a, 2, 3, &b, 2).unwrap();
+
+        // C[i,j] = OR_k (A[i,k] AND B[k,j]); only bit 0 is populated.
+        assert_eq!(c[0], 0x1, "C[0,0] expected lane0 set");
+        assert_eq!(c[1], 0x0, "C[1,0] expected 0 (all-false row)");
+        assert_eq!(c[2], 0x1, "C[0,1] expected lane0 set");
+        assert_eq!(c[3], 0x0, "C[1,1] expected 0");
+    }
+
+    #[test]
+    fn test_tropical_matmul_gpu_bitwise_u32_multilane() {
+        use tropical_gemm::types::TropicalBitwise;
+
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+
+        // Two independent problems in bit 0 and bit 1. Bit 0: same as above (C00=1).
+        // Bit 1: A all-ones, B all-ones -> every C cell has bit 1 set.
+        // A (2x3) and B (3x2), column-major, each u32 holds {bit0, bit1}.
+        let a = vec![0b11u32, 0b10, 0b10, 0b10, 0b11, 0b10];
+        let b = vec![0b11u32, 0b11, 0b10, 0b10, 0b11, 0b11];
+
+        let c = tropical_matmul_gpu::<TropicalBitwise<u32>>(&a, 2, 3, &b, 2).unwrap();
+
+        // Bit 1 (all-ones problem) is set in every cell; bit 0 matches the AndOr
+        // result {1,0,1,0}.
+        assert_eq!(c[0], 0b11, "C[0,0]");
+        assert_eq!(c[1], 0b10, "C[1,0]");
+        assert_eq!(c[2], 0b11, "C[0,1]");
+        assert_eq!(c[3], 0b10, "C[1,1]");
+    }
+
+    #[test]
+    fn test_tropical_matmul_gpu_bitwise_u64() {
+        use tropical_gemm::types::TropicalBitwise;
+
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+
+        // Bit 0 carries the boolean problem; also set bit 63 in the all-ones lane
+        // to exercise the high word of u64.
+        let hi: u64 = 1u64 << 63;
+        let a = vec![1u64 | hi, hi, hi, hi, 1u64 | hi, hi];
+        let b = vec![1u64 | hi, 1u64 | hi, hi, hi, 1u64 | hi, 1u64 | hi];
+
+        let c = tropical_matmul_gpu::<TropicalBitwise<u64>>(&a, 2, 3, &b, 2).unwrap();
+
+        assert_eq!(c[0], 1u64 | hi, "C[0,0]");
+        assert_eq!(c[1], hi, "C[1,0]");
+        assert_eq!(c[2], 1u64 | hi, "C[0,1]");
+        assert_eq!(c[3], hi, "C[1,1]");
+    }
+
+    #[test]
     fn test_error_display() {
         // Test error message formatting
         let err = CudaError::NoDevice;

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -2194,6 +2194,44 @@ mod tests {
     }
 
     #[test]
+    fn test_tropical_matmul_gpu_andor() {
+        use tropical_gemm::types::TropicalAndOr;
+
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+
+        // AndOr (boolean) semiring: C[i,j] = OR_k (A[i,k] AND B[k,j]).
+        // A is 2x3, B is 3x2, both column-major (a[j*m+i], b[j*k+k]).
+        //
+        //       | T F T |            | T F |
+        //   A = | F F F |        B = | T T |
+        //                            | F T |
+        //
+        // Row 1 of A is all-false -> exercises the `false` tropical-zero / pad path.
+        let a = vec![
+            true, false, // col 0: A[0,0]=T, A[1,0]=F
+            false, false, // col 1: A[0,1]=F, A[1,1]=F
+            true, false, // col 2: A[0,2]=T, A[1,2]=F
+        ];
+        let b = vec![
+            true, true, false, // col 0: B[0,0]=T, B[1,0]=T, B[2,0]=F
+            false, true, true, // col 1: B[0,1]=F, B[1,1]=T, B[2,1]=T
+        ];
+
+        let c = tropical_matmul_gpu::<TropicalAndOr>(&a, 2, 3, &b, 2).unwrap();
+
+        // C[0,0] = (T&T) | (F&T) | (T&F) = T  (reachable)
+        assert!(c[0], "C[0,0] expected true");
+        // C[1,0] = (F&T) | (F&T) | (F&F) = F  (all-false row)
+        assert!(!c[1], "C[1,0] expected false");
+        // C[0,1] = (T&F) | (F&T) | (T&T) = T  (reachable via k=2)
+        assert!(c[2], "C[0,1] expected true");
+        // C[1,1] = (F&F) | (F&T) | (F&T) = F
+        assert!(!c[3], "C[1,1] expected false");
+    }
+
+    #[test]
     fn test_error_display() {
         // Test error message formatting
         let err = CudaError::NoDevice;

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -92,6 +92,7 @@ mod context;
 mod error;
 mod gpu_mat;
 mod kernels;
+mod kpack;
 mod memory;
 
 use cudarc::driver::CudaContext as CudaCtx;
@@ -187,6 +188,10 @@ pub use kernels::{
 pub use memory::{
     ArgmaxIndex, ExternalGpuMatrix, ExternalGpuMemory, ExternalGpuTensor3, GpuMatrix,
     GpuMatrixWithArgmax, GpuTensor3, GpuTensor3WithArgmax,
+};
+pub use kpack::{
+    pack_andor_cols_gpu, pack_andor_rows_gpu, tropical_gemm_gpu_andor_packed,
+    tropical_matmul_gpu_andor_packed, AndOrPackedCols, AndOrPackedRows,
 };
 
 // ============================================================================
@@ -2229,6 +2234,167 @@ mod tests {
         assert!(c[2], "C[0,1] expected true");
         // C[1,1] = (F&F) | (F&T) | (F&T) = F
         assert!(!c[3], "C[1,1] expected false");
+    }
+
+    /// Deterministic pseudo-random bool generator (no rand dependency): a simple
+    /// xorshift, thresholded for the requested density (fraction of `true`).
+    fn pseudo_bools(n: usize, density: f64, seed: u64) -> Vec<bool> {
+        let mut s = seed | 1;
+        (0..n)
+            .map(|_| {
+                s ^= s << 13;
+                s ^= s >> 7;
+                s ^= s << 17;
+                // Top 24 bits → [0,1) fraction.
+                let frac = ((s >> 40) as f64) / ((1u64 << 24) as f64);
+                frac < density
+            })
+            .collect()
+    }
+
+    /// The K=0 rejection is a pure host-side check (no GPU), so it runs on the Mac too.
+    #[test]
+    fn test_andor_kpack_rejects_zero_k() {
+        // m=2, k=0, n=2: validate_gemm_input passes (a,b are empty), but the packed
+        // path must reject k==0 with DimensionMismatch.
+        let a: Vec<bool> = vec![];
+        let b: Vec<bool> = vec![];
+        let err = tropical_matmul_gpu_andor_packed(&a, 2, 0, &b, 2).unwrap_err();
+        assert!(
+            matches!(err, CudaError::DimensionMismatch(_)),
+            "expected DimensionMismatch for k=0, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_andor_kpack_matches_byte_kernel() {
+        use tropical_gemm::types::TropicalAndOr;
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+        // Cross-check the packed path against the byte kernel (the GPU-vs-GPU oracle)
+        // across shapes with K both a multiple of 32 and not, and both densities.
+        let shapes: &[(usize, usize, usize)] = &[
+            (1, 1, 1),    // K=1 — only bit 0
+            (3, 31, 4),   // K=31 — single word, bit 31 trap (signed-shift)
+            (5, 32, 6),   // K=32 — exactly one full word
+            (7, 33, 8),   // K=33 — two words, tail in word 1
+            (4, 63, 5),   // K=63 — two words, tail
+            (6, 64, 7),   // K=64 — exactly two full words
+            (9, 65, 3),   // K=65 — three words, tail
+            (16, 128, 16),
+            (33, 100, 17), // non-tile-aligned M,N with non-multiple-of-32 K
+        ];
+        for &(m, k, n) in shapes {
+            for &density in &[0.1_f64, 0.5, 0.9] {
+                let a = pseudo_bools(m * k, density, 0xA11CE + (k as u64) * 31);
+                let b = pseudo_bools(k * n, density, 0xB0B + (n as u64) * 17);
+                let packed =
+                    tropical_matmul_gpu_andor_packed(&a, m, k, &b, n).unwrap();
+                let byte =
+                    tropical_matmul_gpu::<TropicalAndOr>(&a, m, k, &b, n).unwrap();
+                assert_eq!(
+                    packed, byte,
+                    "packed != byte at shape (m={m}, k={k}, n={n}), density={density}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_andor_kpack_bit0_and_bit31_only() {
+        use tropical_gemm::types::TropicalAndOr;
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+        // M=N=1. A reachability that exists ONLY at k=0 (bit 0) and a separate one
+        // ONLY at k=31 (bit 31, the signed-shift trap). K=32: single word.
+        let k = 32;
+        for &hit in &[0usize, 31] {
+            let mut a = vec![false; k];
+            let mut b = vec![false; k];
+            a[hit] = true;
+            b[hit] = true;
+            let packed = tropical_matmul_gpu_andor_packed(&a, 1, k, &b, 1).unwrap();
+            let byte = tropical_matmul_gpu::<TropicalAndOr>(&a, 1, k, &b, 1).unwrap();
+            assert!(packed[0], "expected true for match at k={hit}");
+            assert_eq!(packed, byte, "packed != byte for single match at k={hit}");
+        }
+    }
+
+    #[test]
+    fn test_andor_kpack_adjacent_bit_mismatch_is_false() {
+        use tropical_gemm::types::TropicalAndOr;
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+        // M=N=1, K=32. A sets ONLY bit `p`, B sets ONLY bit `p+1`: the AND of those two
+        // words is 0, so C must be false. This proves AND requires the SAME k position
+        // (a packer that smeared bits across positions would wrongly report true). Sweep
+        // p across a full word incl. the 30/31 boundary (the signed-shift neighborhood).
+        let k = 32;
+        for p in [0usize, 1, 15, 30] {
+            let mut a = vec![false; k];
+            let mut b = vec![false; k];
+            a[p] = true;
+            b[p + 1] = true;
+            let packed = tropical_matmul_gpu_andor_packed(&a, 1, k, &b, 1).unwrap();
+            let byte = tropical_matmul_gpu::<TropicalAndOr>(&a, 1, k, &b, 1).unwrap();
+            assert!(!packed[0], "adjacent bits p={p}/{} must NOT match", p + 1);
+            assert_eq!(packed, byte, "packed != byte for adjacent mismatch p={p}");
+        }
+    }
+
+    #[test]
+    fn test_andor_kpack_guaranteed_false_row() {
+        use tropical_gemm::types::TropicalAndOr;
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+        // M=2, K=40, N=2. Row i=0 of A is entirely false -> the whole output row 0 must
+        // be false regardless of B. Row i=1 shares bit 0 with both B columns -> true.
+        let (m, k, n) = (2usize, 40, 2);
+        let mut a = vec![false; m * k]; // col-major: a[col*m + row]
+        let mut b = vec![false; k * n]; // col-major: b[col*k + row]
+        for col in 0..k {
+            a[col * m + 1] = true; // row 1 all-true; row 0 stays all-false
+        }
+        b[0] = true; // B[0,0]  (col 0, k=0)  == index 0*k + 0
+        b[k] = true; // B[0,1]  (col 1, k=0)  == index 1*k + 0
+        let packed = tropical_matmul_gpu_andor_packed(&a, m, k, &b, n).unwrap();
+        let byte = tropical_matmul_gpu::<TropicalAndOr>(&a, m, k, &b, n).unwrap();
+        // col-major C[row + col*m]: row 0 false in both columns, row 1 true in both.
+        assert!(!packed[0] && !packed[2], "all-false A row must give a false output row");
+        assert!(packed[1] && packed[3], "shared-bit row must be true");
+        assert_eq!(packed, byte, "packed != byte for guaranteed-false-row case");
+    }
+
+    #[test]
+    fn test_andor_kpack_packed_buffers_reusable() {
+        use tropical_gemm::types::TropicalAndOr;
+        if cuda_context_or_skip().is_none() {
+            return;
+        }
+        // GPU-resident path: pack once, run twice against two different B operands,
+        // reusing the packed A. Both results must match the byte kernel.
+        let ctx = cuda_context_or_skip().unwrap();
+        let (m, k, n) = (8, 40, 6);
+        let a = pseudo_bools(m * k, 0.5, 1);
+        let b1 = pseudo_bools(k * n, 0.5, 2);
+        let b2 = pseudo_bools(k * n, 0.3, 3);
+
+        let a_gpu = GpuMatrix::from_host(ctx, &a, m, k).unwrap();
+        let packed_a = pack_andor_rows_gpu(ctx, &a_gpu).unwrap();
+
+        for b in [&b1, &b2] {
+            let b_gpu = GpuMatrix::from_host(ctx, b, k, n).unwrap();
+            let packed_b = pack_andor_cols_gpu(ctx, &b_gpu).unwrap();
+            let mut c_gpu = GpuMatrix::<bool>::alloc(ctx, m, n).unwrap();
+            tropical_gemm_gpu_andor_packed(ctx, &packed_a, &packed_b, &mut c_gpu).unwrap();
+            let got = c_gpu.to_host(ctx).unwrap();
+            let expected = tropical_matmul_gpu::<TropicalAndOr>(&a, m, k, b, n).unwrap();
+            assert_eq!(got, expected, "reused packed A produced wrong result");
+        }
     }
 
     #[test]

--- a/crates/tropical-gemm/src/lib.rs
+++ b/crates/tropical-gemm/src/lib.rs
@@ -34,7 +34,12 @@
 //! | [`TropicalMinPlus<T>`] | min | + | +∞ | 0 | Shortest path |
 //! | [`TropicalMaxMul<T>`] | max | × | 0 | 1 | Probability (non-log) |
 //! | [`TropicalAndOr`] | OR | AND | false | true | Graph reachability |
+//! | [`TropicalBitwise`] | OR | AND | 0 | ~0 | Batched (bit-sliced) boolean matmul |
 //! | [`CountingTropical<T,C>`] | max+count | +,× | (-∞,0) | (0,1) | Path counting |
+//!
+//! `TropicalBitwise<u32/u64>` packs 32/64 **independent** boolean problems into the
+//! bit-lanes of one word. It is for *many independent dense* boolean problems, not a
+//! single large sparse boolean graph — for that use a sparse GraphBLAS tool.
 //!
 //! # Quick Start
 //!
@@ -147,8 +152,9 @@ pub use core::{GemmWithArgmax, Layout, Transpose};
 pub use mat::{Mat, MatMut, MatRef, MatWithArgmax};
 pub use simd::{simd_level, KernelDispatch, SimdLevel};
 pub use types::{
-    CountingTropical, SimdTropical, TropicalAndOr, TropicalMaxMul, TropicalMaxPlus,
-    TropicalMinPlus, TropicalScalar, TropicalSemiring, TropicalWithArgmax,
+    BitwiseScalar, CountingTropical, SimdTropical, TropicalAndOr, TropicalBitwise,
+    TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalScalar, TropicalSemiring,
+    TropicalWithArgmax,
 };
 
 // Convenient type aliases
@@ -160,6 +166,8 @@ pub type MinPlus<T> = TropicalMinPlus<T>;
 pub type MaxMul<T> = TropicalMaxMul<T>;
 /// Alias for [`TropicalAndOr`].
 pub type AndOr = TropicalAndOr;
+/// Alias for [`TropicalBitwise`].
+pub type Bitwise<T> = TropicalBitwise<T>;
 
 /// Prelude module for convenient imports.
 pub mod prelude {
@@ -167,8 +175,9 @@ pub mod prelude {
         tropical_backward_a, tropical_backward_a_batched, tropical_backward_b,
         tropical_backward_b_batched, tropical_matmul, tropical_matmul_batched,
         tropical_matmul_batched_with_argmax, tropical_matmul_strided_batched,
-        tropical_matmul_with_argmax, AndOr, Backend, CountingTropical, GemmWithArgmax, Mat, MatMut,
-        MatRef, MatWithArgmax, MaxMul, MaxPlus, MinPlus, Transpose, TropicalAndOr, TropicalGemm,
-        TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring, TropicalWithArgmax,
+        tropical_matmul_with_argmax, AndOr, Backend, Bitwise, CountingTropical, GemmWithArgmax,
+        Mat, MatMut, MatRef, MatWithArgmax, MaxMul, MaxPlus, MinPlus, Transpose, TropicalAndOr,
+        TropicalBitwise, TropicalGemm, TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus,
+        TropicalSemiring, TropicalWithArgmax,
     };
 }

--- a/crates/tropical-gemm/src/simd/dispatch.rs
+++ b/crates/tropical-gemm/src/simd/dispatch.rs
@@ -1,7 +1,9 @@
 use super::detect::{simd_level, SimdLevel};
 use super::kernels::*;
 use crate::core::{tropical_gemm_inner, TilingParams, Transpose};
-use crate::types::{TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring};
+use crate::types::{
+    TropicalBitwise, TropicalMaxMul, TropicalMaxPlus, TropicalMinPlus, TropicalSemiring,
+};
 
 /// Runtime-dispatched GEMM that selects the best kernel for the current CPU.
 ///
@@ -240,6 +242,8 @@ impl_kernel_dispatch_portable!(
     TropicalMaxMul<i32>,
     TropicalMaxMul<i64>
 );
+
+impl_kernel_dispatch_portable!(TropicalBitwise<u32>, TropicalBitwise<u64>);
 
 #[cfg(test)]
 mod tests {

--- a/crates/tropical-gemm/src/types/bitwise.rs
+++ b/crates/tropical-gemm/src/types/bitwise.rs
@@ -1,0 +1,212 @@
+use super::scalar::TropicalScalar;
+use super::traits::{SimdTropical, TropicalSemiring};
+use std::fmt;
+use std::ops::{Add, BitAnd, BitOr, Mul};
+
+mod sealed {
+    pub trait Sealed {}
+    impl Sealed for u32 {}
+    impl Sealed for u64 {}
+}
+
+/// Unsigned-integer element types valid as a `TropicalBitwise` lane container.
+///
+/// Sealed: only `u32` (32 lanes) and `u64` (64 lanes) are permitted.
+pub trait BitwiseScalar:
+    TropicalScalar + sealed::Sealed + BitOr<Output = Self> + BitAnd<Output = Self>
+{
+    /// All lanes false (tropical zero).
+    const ZERO: Self;
+    /// All lanes true (tropical one), i.e. `!0`.
+    const ONES: Self;
+}
+
+impl BitwiseScalar for u32 {
+    const ZERO: u32 = 0;
+    const ONES: u32 = u32::MAX;
+}
+
+impl BitwiseScalar for u64 {
+    const ZERO: u64 = 0;
+    const ONES: u64 = u64::MAX;
+}
+
+/// TropicalBitwise semiring: `(uint, |, &, 0, ~0)` — bit-packed boolean.
+///
+/// Each bit-lane of the wrapped word is an **independent** boolean problem
+/// (bit-slicing): one GEMM computes 32 (`u32`) or 64 (`u64`) boolean matmuls at
+/// once. `⊕ = |`, `⊗ = &`, zero = `0`, one = `!0`.
+///
+/// This is for **many independent dense boolean problems**. For a single large
+/// (sparse) boolean graph, use a sparse GraphBLAS tool (GraphBLAST / cuBool /
+/// Bit-GraphBLAS) — that is out of scope for this dense library.
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct TropicalBitwise<T: BitwiseScalar>(pub T);
+
+impl<T: BitwiseScalar> TropicalBitwise<T> {
+    /// Create a new TropicalBitwise value from a packed word.
+    #[inline(always)]
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+}
+
+impl<T: BitwiseScalar> TropicalSemiring for TropicalBitwise<T> {
+    type Scalar = T;
+
+    #[inline(always)]
+    fn tropical_zero() -> Self {
+        Self(T::ZERO)
+    }
+
+    #[inline(always)]
+    fn tropical_one() -> Self {
+        Self(T::ONES)
+    }
+
+    #[inline(always)]
+    fn tropical_add(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+
+    #[inline(always)]
+    fn tropical_mul(self, rhs: Self) -> Self {
+        Self(self.0 & rhs.0)
+    }
+
+    #[inline(always)]
+    fn value(&self) -> T {
+        self.0
+    }
+
+    #[inline(always)]
+    fn from_scalar(s: T) -> Self {
+        Self(s)
+    }
+}
+
+impl<T: BitwiseScalar> SimdTropical for TropicalBitwise<T> {
+    // No hand-written bitwise microkernel yet; the portable path handles |/&.
+    const SIMD_AVAILABLE: bool = false;
+    const SIMD_WIDTH: usize = 0;
+}
+
+impl<T: BitwiseScalar> Add for TropicalBitwise<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn add(self, rhs: Self) -> Self::Output {
+        self.tropical_add(rhs)
+    }
+}
+
+impl<T: BitwiseScalar> Mul for TropicalBitwise<T> {
+    type Output = Self;
+
+    #[inline(always)]
+    fn mul(self, rhs: Self) -> Self::Output {
+        self.tropical_mul(rhs)
+    }
+}
+
+impl<T: BitwiseScalar> Default for TropicalBitwise<T> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::tropical_zero()
+    }
+}
+
+impl<T: BitwiseScalar> fmt::Debug for TropicalBitwise<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TropicalBitwise({})", self.0)
+    }
+}
+
+impl<T: BitwiseScalar> fmt::Display for TropicalBitwise<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<T: BitwiseScalar> From<T> for TropicalBitwise<T> {
+    #[inline(always)]
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additive_identity() {
+        let a = TropicalBitwise::<u32>(0b1011);
+        assert_eq!(a.tropical_add(TropicalBitwise::tropical_zero()), a);
+    }
+
+    #[test]
+    fn multiplicative_identity() {
+        let a = TropicalBitwise::<u32>(0b1011);
+        assert_eq!(a.tropical_mul(TropicalBitwise::tropical_one()), a);
+    }
+
+    #[test]
+    fn absorbing_zero() {
+        let a = TropicalBitwise::<u32>(0xDEADBEEF);
+        assert_eq!(
+            a.tropical_mul(TropicalBitwise::tropical_zero()),
+            TropicalBitwise::tropical_zero()
+        );
+    }
+
+    #[test]
+    fn ops_are_bitwise() {
+        let a = TropicalBitwise::<u64>(0b1100);
+        let b = TropicalBitwise::<u64>(0b1010);
+        assert_eq!(a.tropical_add(b).0, 0b1110); // OR
+        assert_eq!(a.tropical_mul(b).0, 0b1000); // AND
+    }
+
+    #[test]
+    fn zero_and_one_values() {
+        assert_eq!(TropicalBitwise::<u32>::tropical_zero().0, 0u32);
+        assert_eq!(TropicalBitwise::<u32>::tropical_one().0, u32::MAX);
+        assert_eq!(TropicalBitwise::<u64>::tropical_one().0, u64::MAX);
+    }
+
+    // Bit-lane 0 of a TropicalBitwise<u32> GEMM must equal the same problem run
+    // as TropicalAndOr (one lane is one AndOr problem). Uses the public matmul
+    // API, which requires KernelDispatch (added in this task).
+    #[test]
+    fn lane0_matches_andor() {
+        use crate::types::TropicalAndOr;
+        use crate::tropical_matmul;
+
+        // 2x3 * 3x2 column-major boolean problem (same as the GPU AndOr test).
+        let a_bool = [true, false, false, false, true, false];
+        let b_bool = [true, true, false, false, true, true];
+
+        let a_u32: Vec<u32> = a_bool.iter().map(|&x| x as u32).collect();
+        let b_u32: Vec<u32> = b_bool.iter().map(|&x| x as u32).collect();
+
+        let c_bw = tropical_matmul::<TropicalBitwise<u32>>(&a_u32, 2, 3, &b_u32, 2);
+
+        let mut c_ao = vec![TropicalAndOr(false); 4];
+        // Safety: 2x3 * 3x2, all leading dims match, no aliasing.
+        unsafe {
+            crate::core::tropical_gemm_portable::<TropicalAndOr>(
+                2, 2, 3,
+                a_bool.as_ptr(), 2, crate::Transpose::NoTrans,
+                b_bool.as_ptr(), 3, crate::Transpose::NoTrans,
+                c_ao.as_mut_ptr(), 2,
+            );
+        }
+
+        for i in 0..4 {
+            let lane0 = (c_bw[i].0 & 1) == 1;
+            assert_eq!(lane0, c_ao[i].0, "cell {i}: bitwise lane0 != andor");
+        }
+    }
+}

--- a/crates/tropical-gemm/src/types/mod.rs
+++ b/crates/tropical-gemm/src/types/mod.rs
@@ -66,6 +66,7 @@
 //! ```
 
 mod and_or;
+mod bitwise;
 mod counting;
 mod max_mul;
 mod max_plus;
@@ -74,6 +75,7 @@ mod scalar;
 mod traits;
 
 pub use and_or::TropicalAndOr;
+pub use bitwise::{BitwiseScalar, TropicalBitwise};
 pub use counting::CountingTropical;
 pub use max_mul::TropicalMaxMul;
 pub use max_plus::TropicalMaxPlus;


### PR DESCRIPTION
Closes the AndOr/Bitwise migration gap from #44. Three stacked steps, the first two reuse the existing tiled GEMM template; Step 3 adds a dedicated bit-packed kernel for the single-matmul case.

## Step 1 — GPU `TropicalAndOr` (regression vs Julia)
`TropicalAndOr` existed on CPU but not GPU, leaving the CUDA backend behind CuTropicalGEMM.jl. Added the boolean semiring (⊕=OR, ⊗=AND, zero=false):
- `TROPICAL_GEMM_BOOL` macro (1-byte `bool`) + `tropical_andor_bool_nn`, registered via `impl_cuda_kernel_bool!`. cudarc already impls `DeviceRepr`/`ValidAsZeroBits` for `bool`.
- The boolean ops use **bitwise `&`/`|` + a single fused accumulation** rather than logical `&&`/`||` with a temp: for 0/1 bytes these are equivalent, but the fused/bitwise form keeps ptxas on the byte-wise `LOP3` path instead of round-tripping each byte through a predicate (`ISETP→PLOP3→P2R`). SASS instruction count drops 2720→1280; the kernel goes from ~1.6× slower than the reference bool kernel to ~12% faster.

## Step 2 — `TropicalBitwise<u32/u64>` (bit-packed, Julia parity)
Bit-slice semiring `(uint, |, &, 0, ~0)`: each word packs 32/64 **independent** boolean problems into bit-lanes; one GEMM computes them all at once. Matches `TropicalNumbers.jl`'s `TropicalBitwise` / `SIMDTypes.Bit`.
- CPU `TropicalBitwise<u32/u64>` (sealed `BitwiseScalar`) + portable `KernelDispatch` (so `tropical_matmul` works) + exports.
- CUDA `tropical_bitwise_u32_nn` / `_u64_nn` (clones of i32/i64). Being 4-/8-byte elements they use **vectorized `LDS.128` loads** (`cuobjdump` confirms `LDS.128 ×64`, identical to i32) instead of the bool kernel's `LDS.U8 ×256` — the byte-load tax is gone, and a u32 carries 32 boolean problems per word.

## Step 3 — K-packed `TropicalAndOr` (single-matmul speedup)

**The problem.** A dense AndOr matmul sums over the contraction axis K (`C[i,j] = ⊕ₖ A[i,k] ⊗ B[k,j]`). The byte kernel spends one `bool` load per K-step — 1 bit of real work inside an 8-bit load, K times. Boolean AND/OR is a *bit* op, so pack 32 K-elements into one `u32` and run the semiring on whole words:

```
                K elements along the contraction axis (one row of A)
byte kernel:  [0000_0001][0000_0000][0000_0001] …   1 bit / 8-bit load, K loads
                   └─ pack 32 per word, LSB-first ─┘
K-packed   :  [ word 0 (32 bits) ][ word 1 ] …       Kw = ⌈K/32⌉ word-loads
```

The matmul ANDs matching words and OR-reduces. Because OR only asks *whether* a shared path exists (not *how many* → no `popcount`), the cell is `true` the instant any bit matches → **early exit**, which a float/int max-plus kernel cannot do:

```
  A row i (packed):  A0    A1    A2   …          acc = 0
  B col j (packed):  B0    B1    B2   …          for w in 0..Kw:
                     │     │     │                    acc |= (Aw & Bw)
                    (&)   (&)   (&)                   if acc != 0: break   ◄─ early exit
                     └──► OR-reduce ◄──┘          C[i,j] = (acc != 0)
```

(Orthogonal to Step 2: that packs *independent problems* into bit-lanes; this packs the *contraction axis of one problem*.)

**Data flow — added 3 `extern "C"` kernels + a Rust packing layer:**

```mermaid
flowchart LR
  A["bool A&nbsp;(M×K)"] -- pack_rows_u32 --> PA["AndOrPackedRows<br/>(M×Kw u32)"]
  B["bool B&nbsp;(K×N)"] -- pack_cols_u32 --> PB["AndOrPackedCols<br/>(Kw×N u32)"]
  PA --> G["tropical_andor_kpack_direct_u32<br/>(acc |= A&amp;B,&nbsp; C = acc≠0)"]
  PB --> G
  G --> C["bool C&nbsp;(M×N)"]
```

- **`pack_rows_u32` / `pack_cols_u32`** — bool → bit-packed `u32`. Two kernels because the crate is **column-major**: a row of A is a strided gather, a column of B is contiguous. LSB-first; the tail is zero-padded (`0` is AND's absorbing element, so padding lanes are inert — the K-loop needs no masking). Packed operands are opaque, reusable handles, so packing is amortized across repeated multiplies.
- **`tropical_andor_kpack_direct_u32`** — one thread per output cell, **no shared memory / no barrier**. That absence is deliberate: it is what makes the early-exit correct (a tiled kernel's `__syncthreads()` between K-tiles would stall a thread trying to bail early). Shipped as the obviously-correct reference; tiled + 1-bit tensor-core (`and.popc`) variants are deferred behind benchmarks.

**API:** `pack_andor_{rows,cols}_gpu`, GPU-resident `tropical_gemm_gpu_andor_packed`, one-shot `tropical_matmul_gpu_andor_packed`. The generic byte path is untouched — explicit opt-in, no runtime dispatch.

**Results (A40, sm_86; kernel-only — operands resident, transfer excluded):**

| K = 4096 | vs byte kernel | vs `MaxPlus<i32>` reuse |
|---|---|---|
| sparse (5% ones) | ~11× | ~7× |
| dense (50% ones) | ~180× | ~117× |

Sparse is the floor (pure 32× loop-shortening); dense is the early-exit firing almost immediately. The bool output is also 1 byte/cell vs 4 → ~4× cheaper to download at the true (pinned) PCIe rate. This is the un-optimized direct kernel, so the numbers are conservative.

### Scope
Bit-slice (Step 2) is for *many independent dense* boolean problems; K-packing (Step 3) accelerates *one* dense boolean matmul. A single large **sparse** boolean graph is out of scope for this dense library — use a sparse GraphBLAS tool (GraphBLAST / cuBool / Bit-GraphBLAS). Also out of scope here: bitwise argmax, a CPU AVX2/NEON bitwise microkernel, popcount / 1-bit tensor-core paths, and a tiled K-packed kernel (Step 3 ships the direct kernel only).

## Tests / validation
- CPU: bitwise bit-lane-0 ↔ `TropicalAndOr` cross-check + identities; full CPU suite green.
- GPU (Steps 1–2): `test_tropical_matmul_gpu_andor`, `_bitwise_u32`, `_bitwise_u32_multilane`, `_bitwise_u64`.
- GPU (Step 3): packed-vs-byte-kernel cross-check across shapes/densities (K both a multiple of 32 and not), dirty-buffer tail-clear (rows + cols), bit-0/bit-31 signed-shift trap, adjacent-bit mismatch, all-false-row, packed-buffer reuse, `K=0` rejection; plus a CPU reference that all four GPU paths (packed / byte / `MaxPlus<i32>` / `MaxPlus<f32>`) must match.
- Validated on **HKUST-GZ A40** (sm_86, CUDA 12.8): full CUDA suite **72/72**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
