### PR TITLE
perf(cuda): make GPU kernel launches asynchronous (drop per-launch device sync)

### DIFF
--- a/crates/tropical-gemm-cuda/src/kernels.rs
+++ b/crates/tropical-gemm-cuda/src/kernels.rs
@@ -1,4 +1,18 @@
 //! CUDA kernel trait and implementations.
+//!
+//! ## Asynchronous launch contract
+//!
+//! Kernel launches in this crate are enqueued on the context's single CUDA
+//! stream and return *without* a device synchronize. Correctness relies on
+//! stream ordering: every operand upload, kernel, and device-to-device copy
+//! runs on that one stream (see `CudaContext::stream`), so each launch
+//! observes its predecessors' results, and any host read goes through
+//! `GpuMatrix::to_host`, which synchronizes. A per-launch
+//! `stream.synchronize()` was previously issued after every kernel; on
+//! contractions built from many small matrices that blocking host↔device
+//! round-trip dominated the wall (one full sync per node) while the GPU sat
+//! idle between tiny kernels, so it has been removed. Callers that need a
+//! barrier (e.g. before timing) can call `ctx.stream().synchronize()`.
 
 use crate::context::CudaContext;
 use crate::error::Result;
@@ -69,7 +83,8 @@ fn launch_kernel_impl<T: DeviceRepr + ValidAsZeroBits + Default + Clone>(
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(())
 }
 
@@ -336,7 +351,8 @@ fn launch_kernel_with_argmax_impl<T: DeviceRepr + ValidAsZeroBits + Default + Cl
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(())
 }
 
@@ -530,7 +546,8 @@ pub unsafe fn launch_gemm_external_with_argmax_f32(
         .arg(&k_i32);
     builder.launch(cfg)?;
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(c)
 }
 
@@ -576,7 +593,8 @@ pub unsafe fn launch_gemm_external_f32(
         .arg(&k_i32);
     builder.launch(cfg)?;
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(c)
 }
 
@@ -660,6 +678,7 @@ pub unsafe fn launch_gemm_external_batched_with_argmax_f32(
         .arg(&stride_c); // strideC
     builder.launch(cfg)?;
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(c)
 }

--- a/crates/tropical-gemm-cuda/src/kpack.rs
+++ b/crates/tropical-gemm-cuda/src/kpack.rs
@@ -99,7 +99,8 @@ fn launch_pack_rows(
     unsafe {
         builder.launch(cfg)?;
     }
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(())
 }
 
@@ -130,7 +131,8 @@ fn launch_pack_cols(
     unsafe {
         builder.launch(cfg)?;
     }
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(())
 }
 
@@ -212,7 +214,8 @@ pub fn tropical_gemm_gpu_andor_packed(
     unsafe {
         builder.launch(cfg)?;
     }
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(())
 }
 

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -959,7 +959,8 @@ pub fn tropical_backward_a_gpu_kernel(
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(grad_a)
 }
 
@@ -1023,7 +1024,8 @@ pub fn tropical_backward_b_gpu_kernel(
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(grad_b)
 }
 


### PR DESCRIPTION
## Problem

Every tropical-GEMM kernel launch helper in `tropical-gemm-cuda` issued a blocking `stream.synchronize()` immediately after enqueuing the kernel:

```rust
unsafe { builder.launch(cfg)?; }
stream.synchronize()?;   // <-- full host<->device round-trip, every launch
```

For a single large matmul this is invisible. But for a **tropical tensor-network contraction made of thousands of tiny nodes** (e.g. max-plus weighted-MIS), it serializes the entire pipeline — the host blocks on each ~few-µs kernel while the GPU sits idle between launches.

## Evidence

An `nsys` CUDA trace of a 9431-node max-plus contraction on an A40:

- **42,442 `cuStreamSynchronize` calls — exactly equal to the 42,442 GEMM kernel instances** (one blocking sync per launch).
- Actual GPU kernel time was only **~36%** of the wall; the rest was the host stalled in these per-launch syncs.
- A network with the *same total arithmetic* packed into a few large nodes was GPU-bound and fast — confirming the gap is per-launch sync overhead, not kernel throughput.

## Fix

Remove the per-launch `stream.synchronize()` from every kernel-launch helper (forward GEMM, argmax, external/DLPack, backward, and K-packed AndOr), making launches **asynchronous** on the context's stream.

This is correctness-preserving:
- All operand uploads, kernels, and device-to-device copies run on the context's **single** stream (`CudaContext::stream()` = the device default stream), so **stream ordering** guarantees each launch observes its predecessors' results.
- Every host read goes through `GpuMatrix::to_host`, which **synchronizes** — those two barriers are kept.
- Callers that want an explicit barrier (e.g. before timing) can call `ctx.stream().synchronize()`.

A module-level doc comment in `kernels.rs` documents this asynchronous-launch contract.

## Notes

- Base is `feat/cuda-andor-gpu` (the branch downstream `omeinsum-rs` / miso pin); retarget to `main` if preferred.
- No API changes; `+34 / -10`, comments + doc only beyond the removed syncs.
- CUDA build/tests validated downstream on A40 (can't compile the `cuda` feature on non-CUDA CI hosts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)