### PR TITLE
perf(cuda): make GPU kernel launches asynchronous (drop per-launch device sync)

### DIFF
--- a/crates/tropical-gemm-cuda/src/kernels.rs
+++ b/crates/tropical-gemm-cuda/src/kernels.rs
@@ -1,4 +1,18 @@
 //! CUDA kernel trait and implementations.
+//!
+//! ## Asynchronous launch contract
+//!
+//! Kernel launches in this crate are enqueued on the context's single CUDA
+//! stream and return *without* a device synchronize. Correctness relies on
+//! stream ordering: every operand upload, kernel, and device-to-device copy
+//! runs on that one stream (see `CudaContext::stream`), so each launch
+//! observes its predecessors' results, and any host read goes through
+//! `GpuMatrix::to_host`, which synchronizes. A per-launch
+//! `stream.synchronize()` was previously issued after every kernel; on
+//! contractions built from many small matrices that blocking host↔device
+//! round-trip dominated the wall (one full sync per node) while the GPU sat
+//! idle between tiny kernels, so it has been removed. Callers that need a
+//! barrier (e.g. before timing) can call `ctx.stream().synchronize()`.
 
 use crate::context::CudaContext;
 use crate::error::Result;
@@ -66,7 +80,8 @@ fn launch_kernel_impl<T: DeviceRepr + ValidAsZeroBits + Default + Clone>(
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(())
 }
 
@@ -251,7 +266,8 @@ fn launch_kernel_with_argmax_impl<T: DeviceRepr + ValidAsZeroBits + Default + Cl
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(())
 }
 
@@ -445,7 +461,8 @@ pub unsafe fn launch_gemm_external_with_argmax_f32(
         .arg(&k_i32);
     builder.launch(cfg)?;
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(c)
 }
 
@@ -491,7 +508,8 @@ pub unsafe fn launch_gemm_external_f32(
         .arg(&k_i32);
     builder.launch(cfg)?;
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(c)
 }
 
@@ -575,6 +593,7 @@ pub unsafe fn launch_gemm_external_batched_with_argmax_f32(
         .arg(&stride_c); // strideC
     builder.launch(cfg)?;
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See the module-level "Asynchronous launch contract".
     Ok(c)
 }

--- a/crates/tropical-gemm-cuda/src/lib.rs
+++ b/crates/tropical-gemm-cuda/src/lib.rs
@@ -954,7 +954,8 @@ pub fn tropical_backward_a_gpu_kernel(
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(grad_a)
 }
 
@@ -1018,7 +1019,8 @@ pub fn tropical_backward_b_gpu_kernel(
         builder.launch(cfg)?;
     }
 
-    stream.synchronize()?;
+    // Async: no per-launch device sync (stream-ordered; host reads sync in
+    // `to_host`). See `kernels::` module docs on the launch contract.
     Ok(grad_b)
 }
 


### PR DESCRIPTION
## Problem

Every tropical-GEMM kernel launch helper in `tropical-gemm-cuda` issued a blocking `stream.synchronize()` immediately after enqueuing the kernel:

```rust
unsafe { builder.launch(cfg)?; }
stream.synchronize()?;   // <-- full host<->device round-trip, every launch
```

Invisible for a single large matmul, but for a **tropical tensor-network contraction made of thousands of tiny nodes** (e.g. max-plus weighted-MIS) it serializes the entire pipeline — the host blocks on each ~few-µs kernel while the GPU sits idle between launches.

## Evidence

`nsys` CUDA trace of a 9431-node max-plus contraction on an A40:

- **42,442 `cuStreamSynchronize` calls — exactly equal to the 42,442 GEMM kernel instances** (one blocking sync per launch).
- Actual GPU kernel time was only **~36%** of the wall; the rest was the host stalled in these syncs.
- The *same total arithmetic* packed into a few large nodes was GPU-bound and fast — so the gap is per-launch sync overhead, not kernel throughput.

## Fix

Remove the per-launch `stream.synchronize()` from every kernel-launch helper (forward GEMM, argmax, external, backward), making launches **asynchronous** on the context's stream.

Correctness-preserving:
- All operand uploads, kernels, and device-to-device copies run on the context's **single** stream (`CudaContext::stream()` = device default stream), so **stream ordering** guarantees each launch observes its predecessors.
- Every host read goes through `GpuMatrix::to_host`, which **synchronizes** — those barriers are kept.
- Callers wanting an explicit barrier (e.g. before timing) can call `ctx.stream().synchronize()`.

A module-level doc in `kernels.rs` documents the asynchronous-launch contract.

## Notes

- `+28 / −7`; comments + doc only beyond the removed syncs. No API changes.
- CUDA build/tests validated downstream on A40 (the `cuda` feature can't compile on non-CUDA CI hosts).
- The same one-line change applies to the K-packed AndOr launchers on `feat/cuda-andor-gpu`; supersedes #59 (opened against that branch) — this PR targets `main` so all downstream consumers get the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)